### PR TITLE
Remove superfluous column name.

### DIFF
--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -41,7 +41,7 @@ class PersonalAccessToken extends Model
      */
     public function user()
     {
-        return $this->belongsTo(Airlock::userModel(), 'user_id');
+        return $this->belongsTo(Airlock::userModel());
     }
 
     /**


### PR DESCRIPTION
Since the method name follows the convention, there is no need to explicitly specify the foreign key.