### PR TITLE
SameSite Cookie Changes in February 2020

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -42,7 +42,6 @@ class EnsureFrontendRequestsAreStateful
     {
         config([
             'session.http_only' => true,
-            'session.same_site' => 'lax',
         ]);
     }
 


### PR DESCRIPTION
We can't set the value to `lax` here, because of the new changes to the way cookies are handled in Chrome. 

If the `same_site` is set to 'lax' requests don't work in Chrome 80+, it says `401 Unauthorized`. It should be set to `none` in `config/session.php`.

Please, see links below: 
https://blog.chromium.org/2020/02/samesite-cookie-changes-in-february.html
https://github.com/laravel/airlock/issues/11#issuecomment-596438725
https://github.com/laravel/airlock/issues/11#issuecomment-598266966

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
