### PR TITLE
[2.x] Make the guard configurable

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -17,19 +17,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Guard
-    |--------------------------------------------------------------------------
-    |
-    | Requests which are authenticated stateful will run through the Laravel's
-    | Authentication guard. Typically this will be the web Guard. However,
-    | you are free to configure the value to your needs.
-    |
-    */
-
-    'guard' => 'web',
-
-    /*
-    |--------------------------------------------------------------------------
     | Expiration Minutes
     |--------------------------------------------------------------------------
     |

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -17,6 +17,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Guard
+    |--------------------------------------------------------------------------
+    |
+    | Requests which are authenticated stateful will run through the Laravel's
+    | Authentication guard. Typically this will be the web Guard. However,
+    | you are free to configure the value to your needs.
+    |
+    */
+
+    'guard' => 'web',
+
+    /*
+    |--------------------------------------------------------------------------
     | Expiration Minutes
     |--------------------------------------------------------------------------
     |

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -42,7 +42,7 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        if ($user = $this->auth->guard('web')->user()) {
+        if ($user = $this->auth->guard(config('sanctum.guard', 'web'))->user()) {
             return $this->supportsTokens($user)
                         ? $user->withAccessToken(new TransientToken)
                         : $user;


### PR DESCRIPTION
I am building a Laravel package which uses sanctum. It was really a missing peace in the eco system. Thanks for this!

However, since I have an additional guard in my package, I had problems to make the described stateful requests.

There was also no way to swap out the implementation via the container because it is instantiated with `new` instead of using the container.

This little change would give me the possibility to go on with this package. I think there is also a discussion about this topic in #20  

There are no breaking changes. 
