### PR TITLE
Add auth guard to sanctum configs

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -42,8 +42,7 @@ return [
     'middleware' => [
         'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
     ],
-
-
+    
     /*
     |--------------------------------------------------------------------------
     | Sanctum Authentication Guard

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -43,4 +43,18 @@ return [
         'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
     ],
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Authentication Guard
+    |--------------------------------------------------------------------------
+    |
+    | This configuration option defines the authentication guard that will
+    | be used to protect your sanctum routes. This option should match one
+    | of the authentication guards defined in the "auth" config file.
+    |
+    */
+
+    'guard' => env('SANCTUM_GUARD', null),
+
 ];


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Added guard to sanctum configs to allow developers to define custom auth guards 

It will not break existing features as the `Guard` class already get the user by `$this->auth->guard(config('sanctum.guard', 'web'))->user()`

I have copied how nova config file define the guard and replaced 'NOVA' with 'SANCTUM' so that it uses the same standards as laravel packages 