### PR TITLE
actingAs any ability

### DIFF
--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -32,8 +32,12 @@ class Sanctum
     {
         $token = Mockery::mock(self::personalAccessTokenModel())->shouldIgnoreMissing(false);
 
-        foreach ($abilities as $ability) {
-            $token->shouldReceive('can')->with($ability)->andReturn(true);
+        if (in_array('*', $abilities)) {
+            $token->shouldReceive('can')->withAnyArgs()->andReturn(true);
+        } else {
+            foreach ($abilities as $ability) {
+                $token->shouldReceive('can')->with($ability)->andReturn(true);
+            }
         }
 
         $user->withAccessToken($token);

--- a/tests/ActingAsTest.php
+++ b/tests/ActingAsTest.php
@@ -65,6 +65,31 @@ class ActingAsTest extends TestCase
         $response->assertSee('bar');
     }
 
+    public function testActingAsWhenKeyHasAnyAbility()
+    {
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        $this->withoutExceptionHandling();
+
+        Route::get('/foo', function () {
+            if (Auth::user()->tokenCan('baz')) {
+                return 'bar';
+            }
+
+            return response(403);
+        })->middleware('auth:sanctum');
+
+        $user = new SanctumUser;
+        $user->id = 1;
+
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->get('/foo');
+
+        $response->assertStatus(200);
+        $response->assertSee('bar');
+    }
+
     protected function getPackageProviders($app)
     {
         return [SanctumServiceProvider::class];


### PR DESCRIPTION
```php
Sanctum::actingAs(
    factory(User::class)->create(),
    ['*']
);
```
Doesn't work as described in the docs.
The mockery instance ends up looking for the argument `'*'` instead of responding with `true` to any `can()` call like the [PersonalAccessToken](https://github.com/laravel/sanctum/blob/2.x/src/PersonalAccessToken.php#L58) does.

A change to `Sanctum::actingAs()` fixes this.
