### PR TITLE
Enhance supportsTokens check

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -73,8 +73,8 @@ class Guard
      */
     protected function supportsTokens($tokenable = null)
     {
-        return in_array(HasApiTokens::class, class_uses_recursive(
-            $tokenable ? get_class($tokenable) : null
+        return $tokenable && in_array(HasApiTokens::class, class_uses_recursive(
+            get_class($tokenable)
         ));
     }
 }


### PR DESCRIPTION
Quick small fix. I don't know if it's 7.4 related, but when I call 

```php
class_uses_recursive(null);
```

it gives me `ErrorException : class_parents(): object or string expected`

I just about the function to test if `$tokenable` if available even before checking the `HasApiTokens` trait usage.