### PR TITLE
[2.x] Allow customizing the query used to get the token

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -51,7 +51,7 @@ class Guard
         if ($token = $request->bearerToken()) {
             $model = Sanctum::$personalAccessTokenModel;
 
-            $accessToken = $model::where('token', hash('sha256', $token))->first();
+            $accessToken = $model::findToken($token);
 
             if (! $accessToken ||
                 ($this->expiration &&

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -48,6 +48,17 @@ class PersonalAccessToken extends Model implements HasAbilities
     }
 
     /**
+     * Find the token instance matching the given token.
+     *
+     * @param  string  $token
+     * @return static
+     */
+    public static function findToken($token)
+    {
+        return static::where('token', hash('sha256', $token))->first();
+    }    
+
+    /**
      * Determine if the token has a given ability.
      *
      * @param  string  $ability
@@ -68,16 +79,5 @@ class PersonalAccessToken extends Model implements HasAbilities
     public function cant($ability)
     {
         return ! $this->can($ability);
-    }
-
-    /**
-     * Find a token.
-     *
-     * @param  string  $token
-     * @return static
-     */
-    public static function findToken($token)
-    {
-        return static::where('token', hash('sha256', $token))->first();
     }
 }

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -69,4 +69,15 @@ class PersonalAccessToken extends Model implements HasAbilities
     {
         return ! $this->can($ability);
     }
+
+    /**
+     * Find a token.
+     *
+     * @param  string  $token
+     * @return static
+     */
+    public static function findToken($token)
+    {
+        return static::where('token', hash('sha256', $token))->first();
+    }
 }


### PR DESCRIPTION
In reference to this issue https://github.com/laravel/sanctum/issues/9

You can already customize how a token is generated by overriding the `createToken` method in your tokenable model.

This PR adds the ability to customize how you'd retrieve a token from the DB, this can be done by defining your own `PersonalAccessToken` class and override the new method `findToken`
