### PR TITLE
No need to specify a provider

### DIFF
--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -21,7 +21,6 @@ class SanctumServiceProvider extends ServiceProvider
         config([
             'auth.guards.sanctum' => array_merge([
                 'driver' => 'sanctum',
-                'provider' => 'users',
             ], config('auth.guards.sanctum', [])),
         ]);
 


### PR DESCRIPTION
Config provider is not used when creating a [RequestGuard](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Auth/AuthManager.php#L229) unlike [SessionGuard](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Auth/AuthManager.php#L123).