### PR TITLE
Add app url domain to stateful

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', 'localhost,127.0.0.1')),
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', 'localhost,127.0.0.1,' . parse_url(env('APP_URL', 'http://localhost'), PHP_URL_HOST))),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', 'localhost,127.0.0.1,' . parse_url(env('APP_URL', 'http://localhost'), PHP_URL_HOST))),
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', 'localhost,127.0.0.1,'.parse_url(env('APP_URL', 'http://localhost'), PHP_URL_HOST))),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Problem: when user create SPA in one project (local + app), sanctum auth cannot work on app because domain APP_URL is not defined in stateful. So good idea is to add SANCTUM_STATEFUL_DOMAINS into .env.

In that pull I added APP_URL domain into stateful to solve that.