### PR TITLE
[2.x] Use origin instead of referer

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -58,7 +58,7 @@ class EnsureFrontendRequestsAreStateful
 
         $origin = Str::replaceFirst('http://', '', $origin);
 
-        return Str::startsWith($referer, config('sanctum.stateful', [])) ||
+        return Str::startsWith($origin, config('sanctum.stateful', [])) ||
                Str::is(config('sanctum.stateful', []), $origin);
     }
 }

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -54,11 +54,11 @@ class EnsureFrontendRequestsAreStateful
      */
     public static function fromFrontend($request)
     {
-        $referer = Str::replaceFirst('https://', '', $request->headers->get('referer'));
+        $origin = Str::replaceFirst('https://', '', $request->headers->get('origin'));
 
-        $referer = Str::replaceFirst('http://', '', $referer);
+        $origin = Str::replaceFirst('http://', '', $origin);
 
         return Str::startsWith($referer, config('sanctum.stateful', [])) ||
-               Str::is(config('sanctum.stateful', []), $referer);
+               Str::is(config('sanctum.stateful', []), $origin);
     }
 }

--- a/tests/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/EnsureFrontendRequestsAreStatefulTest.php
@@ -17,12 +17,12 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
     public function test_request_referer_is_parsed_against_configuration()
     {
         $request = Request::create('/');
-        $request->headers->set('referer', 'https://test.com');
+        $request->headers->set('origin', 'https://test.com');
 
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
 
         $request = Request::create('/');
-        $request->headers->set('referer', 'https://wrong.com');
+        $request->headers->set('origin', 'https://wrong.com');
 
         $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
@@ -30,7 +30,7 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
     public function test_wildcard_matching()
     {
         $request = Request::create('/');
-        $request->headers->set('referer', 'https://foo.test.com');
+        $request->headers->set('origin', 'https://foo.test.com');
 
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }


### PR DESCRIPTION
Good case is made for use of origin instead of referer [here](https://www.sjoerdlangkemper.nl/2019/02/27/prevent-csrf-with-the-origin-http-request-header/). As mentioned, some AV software strip out the referer in requests, which might lead to API requests failing.

The origin header doesn't contain the full path of the referring domain. If, however, there is a need to use the referer for convenience it can be specified as an option to the user in the sanctum config. I can add commits to make this possible if that's considered a better way forward.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
