### PR TITLE
[2.x] more performant tokens lookup

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -49,7 +49,7 @@ trait HasApiTokens
             'abilities' => $abilities,
         ]);
 
-        return new NewAccessToken($token, $plainTextToken);
+        return new NewAccessToken($token, $token->id.'|'.$plainTextToken);
     }
 
     /**

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -55,7 +55,7 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public static function findToken($token)
     {
-        if (! strpos($token, '|')) {
+        if (strpos($token, '|') === false) {
             return static::where('token', hash('sha256', $token))->first();
         }
 

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -62,7 +62,7 @@ class PersonalAccessToken extends Model implements HasAbilities
         [$id, $token] = explode('|', $token);
 
         if ($instance = static::find($id)) {
-            return $instance->token == hash('sha256', $token) ? $instance : null;
+            return $instance->token === hash('sha256', $token) ? $instance : null;
         }
     }
 

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -59,7 +59,7 @@ class PersonalAccessToken extends Model implements HasAbilities
             return static::where('token', hash('sha256', $token))->first();
         }
 
-        [$id, $token] = explode('|', $token);
+        [$id, $token] = explode('|', $token, 2);
 
         if ($instance = static::find($id)) {
             return hash_equals($instance->token, hash('sha256', $token)) ? $instance : null;

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -55,7 +55,15 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public static function findToken($token)
     {
-        return static::where('token', hash('sha256', $token))->first();
+        if (! strpos($token, '|')) {
+            return static::where('token', hash('sha256', $token))->first();
+        }
+
+        [$id, $token] = explode('|', $token);
+
+        if ($instance = static::find($id)) {
+            return $instance->token == hash('sha256', $token) ? $instance : null;
+        }
     }
 
     /**

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -62,7 +62,7 @@ class PersonalAccessToken extends Model implements HasAbilities
         [$id, $token] = explode('|', $token);
 
         if ($instance = static::find($id)) {
-            return $instance->token === hash('sha256', $token) ? $instance : null;
+            return hash_equals($instance->token, hash('sha256', $token)) ? $instance : null;
         }
     }
 

--- a/tests/HasApiTokensTest.php
+++ b/tests/HasApiTokensTest.php
@@ -15,9 +15,16 @@ class HasApiTokensTest extends TestCase
 
         $newToken = $class->createToken('test', ['foo']);
 
+        [$id, $token] = explode('|', $newToken->plainTextToken);
+
         $this->assertEquals(
             $newToken->accessToken->token,
-            hash('sha256', $newToken->plainTextToken)
+            hash('sha256', $token)
+        );
+
+        $this->assertEquals(
+            $newToken->accessToken->id,
+            $id
         );
     }
 


### PR DESCRIPTION
This PR prefixes the plain text token with the token ID so we can lookup that token with a better query performance.