### PR TITLE
[2.x] Fix wildcard subdomain issue

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -54,11 +54,11 @@ class EnsureFrontendRequestsAreStateful
      */
     public static function fromFrontend($request)
     {
-        $referer = Str::replaceFirst('https://', '', $request->headers->get('referer'));
+        $origin = Str::replaceFirst('https://', '', $request->headers->get('origin'));
 
-        $referer = Str::replaceFirst('http://', '', $referer);
+        $origin = Str::replaceFirst('http://', '', $origin);
 
-        return Str::startsWith($referer, config('sanctum.stateful', [])) ||
-               Str::is(config('sanctum.stateful', []), $referer);
+        return Str::startsWith($origin, config('sanctum.stateful', [])) ||
+               Str::is(config('sanctum.stateful', []), $origin);
     }
 }

--- a/tests/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/EnsureFrontendRequestsAreStatefulTest.php
@@ -14,15 +14,15 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $app['config']->set('sanctum.stateful', ['test.com', '*.test.com']);
     }
 
-    public function test_request_referer_is_parsed_against_configuration()
+    public function test_request_origin_is_parsed_against_configuration()
     {
         $request = Request::create('/');
-        $request->headers->set('referer', 'https://test.com');
+        $request->headers->set('origin', 'https://test.com');
 
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
 
         $request = Request::create('/');
-        $request->headers->set('referer', 'https://wrong.com');
+        $request->headers->set('origin', 'https://wrong.com');
 
         $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
@@ -30,7 +30,7 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
     public function test_wildcard_matching()
     {
         $request = Request::create('/');
-        $request->headers->set('referer', 'https://foo.test.com');
+        $request->headers->set('origin', 'https://foo.test.com');
 
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }


### PR DESCRIPTION
At this moment the `EnsureFrontendRequestsAreStateful@fromFrontend` method is basically checking the `referer` header which is somehow works for none wildcard domain , But it isn't works in wildcard subdomain #6 . Because the `referer` header contain the full path url . I changed it to `origin` header check . Which is work perfectly for wildcard subdomain and also for the reguler domain.
![Screenshot 2020-05-07 at 11 33 05 PM](https://user-images.githubusercontent.com/17134979/81326435-a46b4900-90bb-11ea-87bd-f215ade0e22c.png)
