### PR TITLE
[2.x] 419 Exception with requests without referrer

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -58,11 +58,9 @@ class EnsureFrontendRequestsAreStateful
 
         $referer = Str::replaceFirst('http://', '', $referer);
 
-        if (is_null($referer)) {
-            return false;
-        }
+        $stateful = array_filter(config('sanctum.stateful', []));
 
-        return Str::startsWith($referer, config('sanctum.stateful', [])) ||
-               Str::is(config('sanctum.stateful', []), $referer);
+        return Str::startsWith($referer, $stateful) ||
+               Str::is($stateful, $referer);
     }
 }

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -58,6 +58,10 @@ class EnsureFrontendRequestsAreStateful
 
         $referer = Str::replaceFirst('http://', '', $referer);
 
+        if (is_null($referer)) {
+            return false;
+        }
+
         return Str::startsWith($referer, config('sanctum.stateful', [])) ||
                Str::is(config('sanctum.stateful', []), $referer);
     }

--- a/tests/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/EnsureFrontendRequestsAreStatefulTest.php
@@ -35,6 +35,15 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
 
+    public function test_requests_are_not_stateful_without_referer()
+    {
+        $this->app['config']->set('sanctum.stateful', ['']);
+
+        $request = Request::create('/');
+
+        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+    }
+
     protected function getPackageProviders($app)
     {
         return [SanctumServiceProvider::class];


### PR DESCRIPTION
I've figured out an issue with EnsureFrontendRequestsAreStateful middleware. If no value specified for stateful domains in .env, it is considered as blank string and middleware assumes requests is from FrontEnd and applying all following middleware, which results into 419 exception.

#### Steps to Reproduce Bug:

- Set in .env `SANCTUM_STATEFUL_DOMAINS=` without any value
- Make POST request without referrer to guest route registered in api.php (consider calling API from mobile App)
- `EnsureFrontendRequestsAreStateful` middleware assumes request is from FrontEnd as `Str::is()` is matching blank string with null and returns true.