### PR TITLE
[2.x] Optionally disable routes.

### DIFF
--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -21,6 +21,13 @@ class Sanctum
     public static $runsMigrations = true;
 
     /**
+     * Indicates if Sanctum's routes will be added.
+     *
+     * @var bool
+     */
+    public static $hasRoutes = true;
+
+    /**
      * Set the current user for the application with the given abilities.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|\Laravel\Sanctum\HasApiTokens  $user
@@ -82,6 +89,28 @@ class Sanctum
     public static function ignoreMigrations()
     {
         static::$runsMigrations = false;
+
+        return new static;
+    }
+
+    /**
+     * Determine if Sanctum's routes should be added.
+     *
+     * @return bool
+     */
+    public static function hasRoutes()
+    {
+        return static::$hasRoutes;
+    }
+
+    /**
+     * Configure Sanctum to not register its routes.
+     *
+     * @return static
+     */
+    public static function disableRoutes()
+    {
+        static::$hasRoutes = false;
 
         return new static;
     }

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -72,7 +72,7 @@ class SanctumServiceProvider extends ServiceProvider
      */
     protected function defineRoutes()
     {
-        if ($this->app->routesAreCached()) {
+        if (! Sanctum::hasRoutes() || $this->app->routesAreCached()) {
             return;
         }
 


### PR DESCRIPTION
We are using Sanctum for API tokens and Native apps only. Because of this, we don't need to expose the csrf-cookie route. My OCD is not happy with a route being listed that is never being used. This adds the ability to disable the route.
