### PR TITLE
EncryptCookies middleware option in config/sanctum.php

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -41,6 +41,7 @@ return [
 
     'middleware' => [
         'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
+        'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
     ],
 
 ];

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -24,7 +24,7 @@ class EnsureFrontendRequestsAreStateful
 
                 return $next($request);
             },
-            \Illuminate\Cookie\Middleware\EncryptCookies::class,
+            config('sanctum.middleware.encrypt_cookies', \Illuminate\Cookie\Middleware\EncryptCookies::class),
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             config('sanctum.middleware.verify_csrf_token', \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class),


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Added the option to select the middleware for cookies encryption to allow the exclusion of some cookies.
The current implementation use the EncryptCookies middleware of laravel, ignoring the potential changes made by the user in App\Http\Middleware\EncryptCookies.php . This pull request aims to correct the behaviour.
