### PR TITLE
[2.x] Sanctum Guard now falls back to default driver

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -51,7 +51,7 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        if ($user = $this->auth->guard(config('sanctum.guard', $this->auth->getDefaultDriver()))->user()) {
+        if ($user = $this->auth->guard(config('sanctum.guard', config('auth.defaults.guard', 'web')))->user()) {
             return $this->supportsTokens($user)
                         ? $user->withAccessToken(new TransientToken)
                         : $user;

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -51,7 +51,7 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        if ($user = $this->auth->guard(config('sanctum.guard', 'web'))->user()) {
+        if ($user = $this->auth->guard(config('sanctum.guard', $this->auth->getDefaultDriver()))->user()) {
             return $this->supportsTokens($user)
                         ? $user->withAccessToken(new TransientToken)
                         : $user;


### PR DESCRIPTION
I'm running into an issue where I need to use Sanctum for multiple session-based auth guards. This simple change means that I can use `auth()->setDefaultDriver('something-else')` before the `auth:sanctum` middleware is run, and have my guard recognised.

This issue was raised [here](https://github.com/laravel/sanctum/issues/144)