### PR TITLE
Added guard to config file

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -43,5 +43,17 @@ return [
         'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
         'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
     ],
-
+    
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Guard
+    |--------------------------------------------------------------------------
+    |
+    | By default Sanctum will validate sessions agains the web guard,
+    | unless a custom guard has been specified.
+    |
+    */
+    
+    'guard' => 'web',
 ];


### PR DESCRIPTION
After having spent a solid two hours trying to figure out why i could not get Sanctum to authenticate after a successful login, it dawned on me that it was using the wrong guard for session validation. 

Custom guards are already implemented, but not mentioned in the documentation nor config file, so I've added it to the config file for people to find.