### PR TITLE
Remove port from referer to check for hostname

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -57,12 +57,13 @@ class EnsureFrontendRequestsAreStateful
     {
         $referer = Str::replaceFirst('https://', '', $request->headers->get('referer'));
         $referer = Str::replaceFirst('http://', '', $referer);
+        $referer = explode(':', $referer)[0];
         $referer = Str::endsWith($referer, '/') ? $referer : "{$referer}/";
 
         $stateful = array_filter(config('sanctum.stateful', []));
 
         return Str::is(Collection::make($stateful)->map(function ($uri) {
-            return trim($uri).'/*';
+            return trim($uri) . '/*';
         })->all(), $referer);
     }
 }


### PR DESCRIPTION
Our application broke when upgrading to 2.4.x due to the (accidentally?) introduced change of regarding the port to be a part of the domain.

It's debatable whether port should be included, so it's definitely also an option to not merge this, but then maybe we should add some explanation somewhere (or at least make mentioning of this in the changelog).