### PR TITLE
get default guard name from config

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -51,7 +51,7 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        if ($user = $this->auth->guard(config('sanctum.guard', 'web'))->user()) {
+        if ($user = $this->auth->guard(config('sanctum.guard', config('auth.defaults.guard','web')))->user()) {
             return $this->supportsTokens($user)
                         ? $user->withAccessToken(new TransientToken)
                         : $user;


### PR DESCRIPTION
ّIn some applications may not have web guard and it caused to face to "Auth guard [web] is not defined." error.
It is better to try to get default guard from config ("auth.defaults.guard"), if "auth.defaults.guard" didn't present then hard code it to "web".

