### PR TITLE
update(config/sanctum) add undocumented route prefix

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -43,5 +43,15 @@ return [
         'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
         'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
     ],
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Route prefix
+    |--------------------------------------------------------------------------
+    |
+    | This value is the route prefix for /csrf-cookie
+    |
+    */
+    'prefix' => 'sanctum',
 
 ];


### PR DESCRIPTION
There seems to already be a config lookup for "sanctum.prefix" in the route declaration for "/csrf_cookie". This commit adds the prefix to the config surface so that users are aware that they can change it.

Note: this PR doesn't cover the undocumented "sanctum.routes" config lookup.