### PR TITLE
PersonalAccessToken::findToken can also return `null`

### DIFF
--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -51,7 +51,7 @@ class PersonalAccessToken extends Model implements HasAbilities
      * Find the token instance matching the given token.
      *
      * @param  string  $token
-     * @return static
+     * @return static|null
      */
     public static function findToken($token)
     {


### PR DESCRIPTION
PersonalAccessToken::findToken can also return `null`. This PR adds it to the return doc block.