### PR TITLE
[3.x] Enhancement/registers routes

### DIFF
--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -21,6 +21,13 @@ class Sanctum
     public static $runsMigrations = true;
 
     /**
+     * Indicates if Sanctum routes will be registered.
+     *
+     * @var bool
+     */
+    public static $registersRoutes = true;
+
+    /**
      * Set the current user for the application with the given abilities.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|\Laravel\Sanctum\HasApiTokens  $user

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -2,9 +2,10 @@
 
 namespace Laravel\Sanctum;
 
+use Laravel\Sanctum\Sanctum;
 use Illuminate\Auth\RequestGuard;
-use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Sanctum\Http\Controllers\CsrfCookieController;
@@ -74,7 +75,7 @@ class SanctumServiceProvider extends ServiceProvider
      */
     protected function defineRoutes()
     {
-        if ($this->app->routesAreCached() || config('sanctum.routes') === false) {
+        if ($this->app->routesAreCached() || Sanctum::$registersRoutes === false) {
             return;
         }
 

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -4,8 +4,8 @@ namespace Laravel\Sanctum;
 
 use Laravel\Sanctum\Sanctum;
 use Illuminate\Auth\RequestGuard;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Sanctum\Http\Controllers\CsrfCookieController;


### PR DESCRIPTION
### Hey guys,

> Just an opener to say, I absolutely love what you guys have done with Laravel 8! Sanctum, Fortify, JetStream, Livewire, and Inertia are amazing and compliment the development process in Laravel so much!

#### Whats is the reasoning behind my PR?

I wanted to disable the default routes that come with JetStream, Fortify, and Sanctum so my thought process was, let's have a look to see if there is any code in the RouteServiceProvider to enable/disable the routes, similar to the old `Auth::routes()`, nope...

I then began to dig deeper and look into the Service Provider of each vendor package and found the winning code to do this: 
`Fortify::$registersRoutes = false;` and `Jetstream::$registersRoutes = false;`. This left me with just Sanctum, which to my knowledge was actually set via the `sanctum.php` config file.

So my thought behind this PR was to just keep the flow of the codebases as similar as possible and include, in the same format as Fortify and JetStream just so people can have 1 standard to follow instead of config for one package and a variable for another :) 

Please excuse me if this is a waffle of a PR and I'd really like to hear whether you'd prefer to stick down this route of the `registersRoutes` variable or move all packages over to use the `config` 😁
