### PR TITLE
[2.x] Adds origin header fallback

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -55,7 +55,7 @@ class EnsureFrontendRequestsAreStateful
      */
     public static function fromFrontend($request)
     {
-        $domain = ($request->headers->get('referer')) ? $request->headers->get('referer') : $request->headers->get('origin');
+        $domain = $request->headers->get('referer') ?: $request->headers->get('origin');
         $domain = Str::replaceFirst('https://', '', $domain);
         $domain = Str::replaceFirst('http://', '', $domain);
         $domain = Str::endsWith($domain, '/') ? $domain : "{$domain}/";

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -55,14 +55,15 @@ class EnsureFrontendRequestsAreStateful
      */
     public static function fromFrontend($request)
     {
-        $referer = Str::replaceFirst('https://', '', $request->headers->get('referer'));
-        $referer = Str::replaceFirst('http://', '', $referer);
-        $referer = Str::endsWith($referer, '/') ? $referer : "{$referer}/";
+        $domain = ($request->headers->get('referer')) ? $request->headers->get('referer') : $request->headers->get('origin');
+        $domain = Str::replaceFirst('https://', '', $domain);
+        $domain = Str::replaceFirst('http://', '', $domain);
+        $domain = Str::endsWith($domain, '/') ? $domain : "{$domain}/";
 
         $stateful = array_filter(config('sanctum.stateful', []));
 
         return Str::is(Collection::make($stateful)->map(function ($uri) {
             return trim($uri).'/*';
-        })->all(), $referer);
+        })->all(), $domain);
     }
 }

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -56,6 +56,7 @@ class EnsureFrontendRequestsAreStateful
     public static function fromFrontend($request)
     {
         $domain = $request->headers->get('referer') ?: $request->headers->get('origin');
+
         $domain = Str::replaceFirst('https://', '', $domain);
         $domain = Str::replaceFirst('http://', '', $domain);
         $domain = Str::endsWith($domain, '/') ? $domain : "{$domain}/";

--- a/tests/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/EnsureFrontendRequestsAreStatefulTest.php
@@ -37,6 +37,26 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
 
+    public function test_request_origin_fallback()
+    {
+        $request = Request::create('/');
+        $request->headers->set('origin', 'test.com');
+
+        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+        $request = Request::create('/');
+        $request->headers->set('referer', null);
+        $request->headers->set('origin', 'test.com');
+
+        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+        $request = Request::create('/');
+        $request->headers->set('referer', '');
+        $request->headers->set('origin', 'test.com');
+
+        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+    }
+
     public function test_wildcard_matching()
     {
         $request = Request::create('/');


### PR DESCRIPTION
Adds an `origin` fallback if the `referer` has been stripped. Closes #203.