### PR TITLE
[2.x] Return correct CSRF Token 

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -20,14 +20,14 @@ class EnsureFrontendRequestsAreStateful
         $this->configureSecureCookieSessions();
 
         return (new Pipeline(app()))->send($request)->through(static::fromFrontend($request) ? [
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
             function ($request, $next) {
                 $request->attributes->set('sanctum', true);
 
                 return $next($request);
             },
             config('sanctum.middleware.encrypt_cookies', \Illuminate\Cookie\Middleware\EncryptCookies::class),
-            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
             config('sanctum.middleware.verify_csrf_token', \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class),
         ] : [])->then(function ($request) use ($next) {
             return $next($request);


### PR DESCRIPTION
First we need add cookies to response then start the session and only after that encrypt cookies.
Otherwise, while requesting for new cookies we will get the error: CSRF token mismatch

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
