### PR TITLE
[2.x] Fix user provider in `sanctum` guard

### DIFF
--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -114,7 +114,7 @@ class SanctumServiceProvider extends ServiceProvider
         return new RequestGuard(
             new Guard($auth, config('sanctum.expiration'), $config['provider']),
             $this->app['request'],
-            $auth->createUserProvider()
+            $auth->createUserProvider($config['provider'])
         );
     }
 

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -114,7 +114,7 @@ class SanctumServiceProvider extends ServiceProvider
         return new RequestGuard(
             new Guard($auth, config('sanctum.expiration'), $config['provider']),
             $this->app['request'],
-            $auth->createUserProvider($config['provider'])
+            $auth->createUserProvider($config['provider'] ?? null)
         );
     }
 


### PR DESCRIPTION
This PR provides the specified user provider to the `sanctum` guard.

Without that, the `Illuminate\Auth\RequestGuard` is constructed without a user provider by default, which is inconsistent with the `Laravel\Sanctum\Guard` callable which accepts the specified user provider.

I've added tests to prove that the `sanctum` guard is not properly configured:

The `Laravel\Sanctum\Guard` callable accepts the specified provider in the constructor from the configuration, and validates if the provider model matches the authenticated model. This part is working correctly.

In the service provider, the actual guard `Illuminate\Auth\RequestGuard` is constructed with the default application provider which is `null`, instead of the specified provider in the configuration.

So, calling `Auth::guard('sanctum')->user()` or `Auth::guard('sanctum')->validate()` will succeed because it's using the user provider configured in the service provider.

But `Auth::guard('sanctum')->getProvider()` will return `null`. With this fix it will return the correct user provider.