### PR TITLE
Change bigIncrements('id') to id() in migration

### DIFF
--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -14,7 +14,7 @@ class CreatePersonalAccessTokensTable extends Migration
     public function up()
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->id();
             $table->morphs('tokenable');
             $table->string('name');
             $table->string('token', 64)->unique();


### PR DESCRIPTION
Changed id column in  `2019_12_14_000001_create_personal_access_tokens_table.php`

I am not sure why in all Jetstream scaffolding this is the only place which is not changed to id(), I am not sure maybe someone can explain if it got a reason, 
if not then I think it's good to be consistent. 😅

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
