### PR TITLE
Added Sanctum Default Guard

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -20,6 +20,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sanctum Guard
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which authentication guard Sanctum will use while
+    | authenticating users. This value should correspond with one of your
+    | guards that is already present in your "auth" configuration file.
+    |
+    */
+
+    'guard' => 'web',
+
+    /*
+    |--------------------------------------------------------------------------
     | Expiration Minutes
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Here you may specify which authentication guard Sanctum will use whileauthenticating users. This value should correspond with one of your guards that is already present in your "auth" configuration file.