### PR TITLE
Add APP_URL to default sateful domain list

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -13,10 +13,22 @@ return [
     |
     */
 
-    'stateful' => explode(',', env(
-        'SANCTUM_STATEFUL_DOMAINS',
-        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1'
-    )),
+    'stateful' => Illuminate\Support\Str::of(
+        env(
+            'SANCTUM_STATEFUL_DOMAINS',
+            env('APP_URL') . ',localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1'
+        )
+    )
+        ->explode(',')
+        ->map(
+            function ($host) {
+                return preg_replace('#^https?://#', '', $host);
+            }
+        )
+        ->filter()
+        ->unique()
+        ->values()
+        ->all(),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\Sanctum\Tests;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Orchestra\Testbench\TestCase;
+
+class ConfigTest extends TestCase
+{
+    use WithFaker;
+
+    public function test_default_stateful_value_contains_app_url()
+    {
+        $previousAppUrl = getenv('APP_URL');
+        $domain = $this->faker->domainName;
+        putenv("APP_URL={$domain}");
+
+        $config = require __DIR__ . '/../config/sanctum.php';
+        $stateful = $config['stateful'] ?? [];
+
+        $this->assertContains($domain, $stateful);
+
+        putenv("APP_URL={$previousAppUrl}");
+    }
+}


### PR DESCRIPTION
Currently when setting up sanctum on a new project the project domain has to be added to the stateful list.

A nice-to-have feature would be to also add the domain based on the APP_URL environment variable.
