### PR TITLE
[2.x] Add support multiple guard for SPA auth

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -51,10 +51,18 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        if ($user = $this->auth->guard(config('sanctum.guard', 'web'))->user()) {
-            return $this->supportsTokens($user)
-                        ? $user->withAccessToken(new TransientToken)
-                        : $user;
+        $guards = array_keys(config('auth.guards'));
+
+        if (empty($guards)) {
+            $guards = [null];
+        }
+
+        foreach ($guards as $guard) {
+            if ($user = $this->auth->guard($guard)->user()) {
+                return $this->supportsTokens($user)
+                    ? $user->withAccessToken(new TransientToken)
+                    : $user;
+            }
         }
 
         if ($token = $request->bearerToken()) {

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -51,17 +51,27 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        $guards = array_keys(config('auth.guards'));
-
-        if (empty($guards)) {
-            $guards = [null];
-        }
-
-        foreach ($guards as $guard) {
-            if ($user = $this->auth->guard($guard)->user()) {
+        if ($default_guard = config('sanctum.guard')) {
+            if ($user = $this->auth->guard($default_guard)->user()) {
                 return $this->supportsTokens($user)
                     ? $user->withAccessToken(new TransientToken)
                     : $user;
+            }
+        } else {
+            $guards = collect(config('auth.guards'))->filter(function ($guard) {
+                return $guard['driver'] === 'session';
+            })->keys();
+
+            if (empty($guards)) {
+                $guards = [null];
+            }
+
+            foreach ($guards as $guard) {
+                if ($user = $this->auth->guard($guard)->user()) {
+                    return $this->supportsTokens($user)
+                        ? $user->withAccessToken(new TransientToken)
+                        : $user;
+                }
             }
         }
 


### PR DESCRIPTION

This pull request adds support to multiple guards for SPA Authentication.

By default it will take the `sanctum.guard` value, if not it will get all the guards set in `auth.guards` that the drivers are session.

Iterates all the valid `guards` and returns the first item that matches.

