### PR TITLE
[2.x] Add multiple guard support for SPA auth

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -20,6 +20,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which authentication guards Sanctum will use while
+    | authenticating users. This values should correspond with the
+    | guards that are already present in your "auth" configuration file.
+    |
+    */
+
+    'guards' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
     | Expiration Minutes
     |--------------------------------------------------------------------------
     |

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -51,27 +51,13 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        if ($default_guard = config('sanctum.guard')) {
-            if ($user = $this->auth->guard($default_guard)->user()) {
+        $guards = config('sanctum.guards');
+
+        foreach ($guards as $guard) {
+            if ($user = $this->auth->guard($guard)->user()) {
                 return $this->supportsTokens($user)
                     ? $user->withAccessToken(new TransientToken)
                     : $user;
-            }
-        } else {
-            $guards = collect(config('auth.guards'))->filter(function ($guard) {
-                return $guard['driver'] === 'session';
-            })->keys();
-
-            if (empty($guards)) {
-                $guards = [null];
-            }
-
-            foreach ($guards as $guard) {
-                if ($user = $this->auth->guard($guard)->user()) {
-                    return $this->supportsTokens($user)
-                        ? $user->withAccessToken(new TransientToken)
-                        : $user;
-                }
             }
         }
 

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -51,10 +51,18 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        if ($user = $this->auth->guard(config('sanctum.guard', 'web'))->user()) {
-            return $this->supportsTokens($user)
-                        ? $user->withAccessToken(new TransientToken)
-                        : $user;
+        $guards = array_keys(config('auth.guards'));
+
+        if (empty($guards)) {
+            $guards = [null];
+        }
+
+        foreach ($guards as $guard) {
+            if ($user = $this->auth->guard($guard)->user()) {
+                return $this->supportsTokens($user)
+                    ? $user->withAccessToken(new TransientToken)
+                    : $user;
+            }
         }
 
         if ($token = $request->bearerToken()) {

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -51,17 +51,27 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        $guards = array_keys(config('auth.guards'));
-
-        if (empty($guards)) {
-            $guards = [null];
-        }
-
-        foreach ($guards as $guard) {
-            if ($user = $this->auth->guard($guard)->user()) {
+        if ($default_guard = config('sanctum.guard')) {
+            if ($user = $this->auth->guard($default_guard)->user()) {
                 return $this->supportsTokens($user)
                     ? $user->withAccessToken(new TransientToken)
                     : $user;
+            }
+        } else {
+            $guards = collect(config('auth.guards'))->filter(function ($guard) {
+                return $guard['driver'] === 'session';
+            })->keys();
+
+            if (empty($guards)) {
+                $guards = [null];
+            }
+
+            foreach ($guards as $guard) {
+                if ($user = $this->auth->guard($guard)->user()) {
+                    return $this->supportsTokens($user)
+                        ? $user->withAccessToken(new TransientToken)
+                        : $user;
+                }
             }
         }
 


### PR DESCRIPTION
This pull request adds support to multiple guards for SPA Authentication.

It will take guards set in `sanctum.guards` iterate and return the first item that matches.

These guards should correspond with the guards that are already present in the `auth` configuration file.