### PR TITLE
[2.x] Return json response when the request expects a json

### DIFF
--- a/src/Http/Controllers/CsrfCookieController.php
+++ b/src/Http/Controllers/CsrfCookieController.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Sanctum\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
 class CsrfCookieController
@@ -11,8 +13,12 @@ class CsrfCookieController
      *
      * @return \Illuminate\Http\Response
      */
-    public function show()
+    public function show(Request $request)
     {
+        if ($request->expectsJson()) {
+            return new JsonResponse(null, 204);
+        }
+
         return new Response('', 204);
     }
 }

--- a/src/Http/Controllers/CsrfCookieController.php
+++ b/src/Http/Controllers/CsrfCookieController.php
@@ -11,6 +11,7 @@ class CsrfCookieController
     /**
      * Return an empty response simply to trigger the storage of the CSRF cookie in the browser.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
     public function show(Request $request)


### PR DESCRIPTION
There is known issue with Laravel Sanctum in Postman (https://github.com/postmanlabs/postman-app-support/issues/2418#issuecomment-645771459).

If `sanctum/csrf-cookie` support returning JsonResponse, somehow it fixed those issue. So, when a Postman user sending request to the `sanctum/csrf-cookie`, they need to pass `Accept` header as `application/json` to make it working.