### PR TITLE
[3.x] Add expires_at functionality to tokens.

### DIFF
--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -20,6 +20,7 @@ class CreatePersonalAccessTokensTable extends Migration
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();
             $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
             $table->timestamps();
         });
     }

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -65,6 +65,8 @@ class Guard
             if (! $accessToken ||
                 ($this->expiration &&
                  $accessToken->created_at->lte(now()->subMinutes($this->expiration))) ||
+                ($accessToken->expires_at &&
+                    $accessToken->expires_at->isPast()) ||
                 ! $this->hasValidProvider($accessToken->tokenable)) {
                 return;
             }

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Sanctum;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
 trait HasApiTokens
@@ -39,14 +40,16 @@ trait HasApiTokens
      *
      * @param  string  $name
      * @param  array  $abilities
+     * @param  Carbon|null $expires_at
      * @return \Laravel\Sanctum\NewAccessToken
      */
-    public function createToken(string $name, array $abilities = ['*'])
+    public function createToken(string $name, array $abilities = ['*'], Carbon $expires_at = null)
     {
         $token = $this->tokens()->create([
             'name' => $name,
             'token' => hash('sha256', $plainTextToken = Str::random(40)),
             'abilities' => $abilities,
+            'expires_at' => $expires_at,
         ]);
 
         return new NewAccessToken($token, $token->id.'|'.$plainTextToken);

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -27,7 +27,7 @@ class PersonalAccessToken extends Model implements HasAbilities
         'name',
         'token',
         'abilities',
-        'expires_at'
+        'expires_at',
     ];
 
     /**

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -15,6 +15,7 @@ class PersonalAccessToken extends Model implements HasAbilities
     protected $casts = [
         'abilities' => 'json',
         'last_used_at' => 'datetime',
+        'expires_at' => 'datetime',
     ];
 
     /**
@@ -26,6 +27,7 @@ class PersonalAccessToken extends Model implements HasAbilities
         'name',
         'token',
         'abilities',
+        'expires_at'
     ];
 
     /**

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -120,6 +120,86 @@ class GuardTest extends TestCase
         $this->assertNull($user);
     }
 
+    public function test_authentication_with_token_fails_if_expires_at_has_passed()
+    {
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        $factory = Mockery::mock(AuthFactory::class);
+
+        $guard = new Guard($factory, null, 'users');
+
+        $webGuard = Mockery::mock(stdClass::class);
+
+        $factory->shouldReceive('guard')
+            ->with('web')
+            ->andReturn($webGuard);
+
+        $webGuard->shouldReceive('user')->once()->andReturn(null);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('Authorization', 'Bearer test');
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
+            'remember_token' => Str::random(10),
+        ]);
+
+        $token = PersonalAccessToken::forceCreate([
+            'tokenable_id' => $user->id,
+            'tokenable_type' => get_class($user),
+            'name' => 'Test',
+            'token' => hash('sha256', 'test'),
+            'expires_at' => now()->subMinutes(60),
+        ]);
+
+        $user = $guard->__invoke($request);
+
+        $this->assertNull($user);
+    }
+
+    public function test_authentication_with_token_succeeds_if_expires_at_not_passed()
+    {
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        $factory = Mockery::mock(AuthFactory::class);
+
+        $guard = new Guard($factory, null, 'users');
+
+        $webGuard = Mockery::mock(stdClass::class);
+
+        $factory->shouldReceive('guard')
+            ->with('web')
+            ->andReturn($webGuard);
+
+        $webGuard->shouldReceive('user')->once()->andReturn(null);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('Authorization', 'Bearer test');
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
+            'remember_token' => Str::random(10),
+        ]);
+
+        $token = PersonalAccessToken::forceCreate([
+            'tokenable_id' => $user->id,
+            'tokenable_type' => get_class($user),
+            'name' => 'Test',
+            'token' => hash('sha256', 'test'),
+            'expires_at' => now()->addMinutes(60),
+        ]);
+
+        $user = $guard->__invoke($request);
+
+        $this->assertNull($user);
+    }
+
     public function test_authentication_is_successful_with_token_if_no_session_present()
     {
         $this->loadLaravelMigrations(['--database' => 'testbench']);

--- a/tests/HasApiTokensTest.php
+++ b/tests/HasApiTokensTest.php
@@ -2,18 +2,20 @@
 
 namespace Laravel\Sanctum\Tests;
 
+use Illuminate\Support\Carbon;
 use Laravel\Sanctum\HasApiTokens;
 use Laravel\Sanctum\PersonalAccessToken;
 use Laravel\Sanctum\TransientToken;
-use PHPUnit\Framework\TestCase;
+use Orchestra\Testbench\TestCase;
 
 class HasApiTokensTest extends TestCase
 {
     public function test_tokens_can_be_created()
     {
         $class = new ClassThatHasApiTokens;
+        $time = Carbon::now();
 
-        $newToken = $class->createToken('test', ['foo']);
+        $newToken = $class->createToken('test', ['foo'], $time);
 
         [$id, $token] = explode('|', $newToken->plainTextToken);
 
@@ -25,6 +27,11 @@ class HasApiTokensTest extends TestCase
         $this->assertEquals(
             $newToken->accessToken->id,
             $id
+        );
+
+        $this->assertEquals(
+            $time->toDateTimeString(),
+            $newToken->accessToken->expires_at->toDateTimeString()
         );
     }
 


### PR DESCRIPTION
Adds an expires_at timestamp to tokens. If the expires_at has passed, the token can no longer be used. 

This may allow users to set different expiration times for different tokens. So you can create a token used for a one-time import that expires in automatically in a week, and a token that generates daily reports that doesn't expire.

This also lets developers enforce different expiration times for different tokens based on the type of user, or the privileges of the token.



