### PR TITLE
[PHP 8.1] Avoid running string functions when domain is null

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -57,6 +57,10 @@ class EnsureFrontendRequestsAreStateful
     {
         $domain = $request->headers->get('referer') ?: $request->headers->get('origin');
 
+        if (is_null($domain)) {
+            return false;
+        }
+
         $domain = Str::replaceFirst('https://', '', $domain);
         $domain = Str::replaceFirst('http://', '', $domain);
         $domain = Str::endsWith($domain, '/') ? $domain : "{$domain}/";


### PR DESCRIPTION
Fixes an issue in PHP 8.1 where a request with no `Referer` or `Origin` header will throw a deprecation warning (transformed to an `ErrorException` in tests) when `Str::replaceFirst` attempts to call `strpos` with `null` as the first argument.

Once PHP 8.1 is added to the matrix, this will be automatically covered by [`test_requests_are_not_stateful_without_referer`][1].

**Context:**
* I recently switched my project from Passport to Sanctum, using cookie-based SPA auth
* When I later added PHP 8.1 to the GH Actions workflow, all frontend tests hitting Sanctum's middleware were failing

---

### Stacktrace

```
[2021-03-06 13:01:23] testing.ERROR:
    strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated { "userId":1,
    "exception":"[object] (
        ErrorException(code: 0):
			strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
			 at ./vendor/laravel/framework/src/Illuminate/Support/Str.php:529)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 ./vendor/laravel/framework/src/Illuminate/Support/Str.php(529): strpos()
#2 ./vendor/laravel/sanctum/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php(60): Illuminate\\Support\\Str::replaceFirst()
#3 ./vendor/laravel/sanctum/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php(22): Laravel\\Sanctum\\Http\\Middleware\\EnsureFrontendRequestsAreStateful::fromFrontend()
#4 ./vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Laravel\\Sanctum\\Http\\Middleware\\EnsureFrontendRequestsAreStateful->handle()
#5 ./vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(103): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#6 ./vendor/laravel/framework/src/Illuminate/Routing/Router.php(695): Illuminate\\Pipeline\\Pipeline->then()
#7 ./vendor/laravel/framework/src/Illuminate/Routing/Router.php(670): Illuminate\\Routing\\Router->runRouteWithinStack()
#8 ./vendor/laravel/framework/src/Illuminate/Routing/Router.php(636): Illuminate\\Routing\\Router->runRoute()
#9 ./vendor/laravel/framework/src/Illuminate/Routing/Router.php(625): Illuminate\\Routing\\Router->dispatchToRoute()
#10 ./vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(166): Illuminate\\Routing\\Router->dispatch()
#11 ./vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(128): Illuminate\\Foundation\\Http\\Kernel->Illuminate\\Foundation\\Http\\{closure}()
#12 ./vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php(21): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#13 ./vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest->handle()
#14 ./vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php(21): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#15 ./vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest->handle()
#16 ./vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ValidatePostSize.php(27): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#17 ./vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize->handle()
#18 ./vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php(86): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#19 ./vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Illuminate\\Foundation\\Http\\Middleware\\PreventRequestsDuringMaintenance->handle()
#20 ./vendor/fruitcake/laravel-cors/src/HandleCors.php(57): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#21 ./vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Fruitcake\\Cors\\HandleCors->handle()
#22 ./vendor/fideloper/proxy/src/TrustProxies.php(57): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#23 ./vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): Fideloper\\Proxy\\TrustProxies->handle()
#24 ./vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(103): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#25 ./vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(141): Illuminate\\Pipeline\\Pipeline->then()
#26 ./vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(110): Illuminate\\Foundation\\Http\\Kernel->sendRequestThroughRouter()
#27 ./vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php(508): Illuminate\\Foundation\\Http\\Kernel->handle()
#28 ./vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php(474): Illuminate\\Foundation\\Testing\\TestCase->call()
#29 ./vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php(304): Illuminate\\Foundation\\Testing\\TestCase->json()
#30 ./tests/Unit/Http/FallbackRouteTest.php(42): Illuminate\\Foundation\\Testing\\TestCase->getJson()
#31 ./vendor/phpunit/phpunit/src/Framework/TestCase.php(1526): Tests\\Unit\\Http\\FallbackRouteTest->nonexistant_api_routes_respond_with_404()
#32 ./vendor/phpunit/phpunit/src/Framework/TestCase.php(1132): PHPUnit\\Framework\\TestCase->runTest()
#33 ./vendor/phpunit/phpunit/src/Framework/TestResult.php(722): PHPUnit\\Framework\\TestCase->runBare()
#34 ./vendor/phpunit/phpunit/src/Framework/TestCase.php(884): PHPUnit\\Framework\\TestResult->run()
#35 ./vendor/phpunit/phpunit/src/Framework/TestSuite.php(677): PHPUnit\\Framework\\TestCase->run()
#36 ./vendor/phpunit/phpunit/src/Framework/TestSuite.php(677): PHPUnit\\Framework\\TestSuite->run()
#37 ./vendor/phpunit/phpunit/src/Framework/TestSuite.php(677): PHPUnit\\Framework\\TestSuite->run()
#38 ./vendor/phpunit/phpunit/src/TextUI/TestRunner.php(667): PHPUnit\\Framework\\TestSuite->run()
#39 ./vendor/phpunit/phpunit/src/TextUI/Command.php(142): PHPUnit\\TextUI\\TestRunner->run()
#40 ./vendor/phpunit/phpunit/src/TextUI/Command.php(95): PHPUnit\\TextUI\\Command->run()
#41 ./vendor/phpunit/phpunit/phpunit(61): PHPUnit\\TextUI\\Command::main()
#42 {main}
"}
```

[1]: https://github.com/laravel/sanctum/blob/70a82a6d2bab615a6e5505aab88eca83c692a508/tests/EnsureFrontendRequestsAreStatefulTest.php#L68-L75