### PR TITLE
[2.x] Changed Primary Key will not be used in created token's plainTextToken

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -49,7 +49,7 @@ trait HasApiTokens
             'abilities' => $abilities,
         ]);
 
-        return new NewAccessToken($token, $token->id.'|'.$plainTextToken);
+        return new NewAccessToken($token, $token->getKey().'|'.$plainTextToken);
     }
 
     /**


### PR DESCRIPTION
As described in #261 a changed primary key name will not be used when creating tokens