### PR TITLE
[2.x] Environment APP_URL added into the default sanctum.stateful configuration

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -15,7 +15,7 @@ return [
 
     'stateful' => explode(',', env(
         'SANCTUM_STATEFUL_DOMAINS',
-        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1,' . parse_url(env('APP_URL'), PHP_URL_HOST)
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1,'.parse_url(env('APP_URL'), PHP_URL_HOST)
     )),
 
     /*

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -15,7 +15,7 @@ return [
 
     'stateful' => explode(',', env(
         'SANCTUM_STATEFUL_DOMAINS',
-        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1'
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1,' . parse_url(env('APP_URL'), PHP_URL_HOST)
     )),
 
     /*

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,9 @@
          processIsolation="false"
          stopOnFailure="false"
 >
+    <php>
+        <env name="APP_URL" value="https://www.test.com"/>
+    </php>
     <testsuites>
         <testsuite name="Sanctum Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/tests/DefaultConfigContainsAppUrlTest.php
+++ b/tests/DefaultConfigContainsAppUrlTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Sanctum\Tests;
+
+use Illuminate\Http\Request;
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Orchestra\Testbench\TestCase;
+
+class DefaultConfigContainsAppUrlTest extends TestCase
+{
+    protected function useDefaultStatefulConfiguration($app)
+    {
+        $config = require __DIR__ . '/../config/sanctum.php';
+
+        $app->config->set('sanctum.stateful', $config['stateful']);
+    }
+
+    public function test_default_config_contains_app_url()
+    {
+        $config = require __DIR__ . '/../config/sanctum.php';
+
+        $app_host = parse_url(getenv('APP_URL'), PHP_URL_HOST);
+
+        $this->assertContains($app_host, $config['stateful']);
+    }
+
+    /**
+     * @environment-setup useDefaultStatefulConfiguration
+     */
+    public function test_request_from_app_url_is_stateful_with_default_config()
+    {
+        $request = Request::create('/');
+        $request->headers->set('referer', env('APP_URL'));
+
+        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+    }
+}

--- a/tests/DefaultConfigContainsAppUrlTest.php
+++ b/tests/DefaultConfigContainsAppUrlTest.php
@@ -10,14 +10,14 @@ class DefaultConfigContainsAppUrlTest extends TestCase
 {
     protected function useDefaultStatefulConfiguration($app)
     {
-        $config = require __DIR__ . '/../config/sanctum.php';
+        $config = require __DIR__.'/../config/sanctum.php';
 
         $app->config->set('sanctum.stateful', $config['stateful']);
     }
 
     public function test_default_config_contains_app_url()
     {
-        $config = require __DIR__ . '/../config/sanctum.php';
+        $config = require __DIR__.'/../config/sanctum.php';
 
         $app_host = parse_url(getenv('APP_URL'), PHP_URL_HOST);
 

--- a/tests/DefaultConfigContainsAppUrlTest.php
+++ b/tests/DefaultConfigContainsAppUrlTest.php
@@ -19,7 +19,7 @@ class DefaultConfigContainsAppUrlTest extends TestCase
     {
         $config = require __DIR__.'/../config/sanctum.php';
 
-        $app_host = parse_url(getenv('APP_URL'), PHP_URL_HOST);
+        $app_host = parse_url(env('APP_URL'), PHP_URL_HOST);
 
         $this->assertContains($app_host, $config['stateful']);
     }


### PR DESCRIPTION
## What?

Added the application's URL from `.env`'s `APP_URL` to the default value of `sanctum.stateful` configuration.

## Why?

In my experience (teaching new Laravel developers) not having the application's URL among default stateful domains leads to a lot of headache when deploying to a production environment. The URL changes from e.g. `localhost:3000` to `www.test.com` and suddenly a new configuration value must be added into `.env` which was not needed until now.

While everyone expects they should change the `APP_URL` when moving to a new environment, few also remember to add `SANCTUM_STATEFUL_DOMAINS`

This is also hard to notice because the application works, only the requests which should be authenticated are not.

## How?

Added the host part of the `APP_URL` environment value to `/config/sanctum.php` 

## Testing

I needed to modify the `phpunit.xml.dist` file to provide a sample env `APP_URL` configuration that could be loaded with the `env()` function.

Tests test the presence of the host of `env('APP_URL')` in `config('sanctum.stateful'`) and that a request coming from the environment `APP_URL` configuration passes the `Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::fromFrontend()` check.

## Duplicite PR?

This may seem like a duplicite of #243 but does the same thing with much simpler code and the test suite passes.
