### PR TITLE
adjust request usage for octane

### DIFF
--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -95,9 +95,7 @@ class SanctumServiceProvider extends ServiceProvider
     {
         Auth::resolved(function ($auth) {
             $auth->extend('sanctum', function ($app, $name, array $config) use ($auth) {
-                return tap($this->createGuard($auth, $config), function ($guard) {
-                    $this->app->refresh('request', $guard, 'setRequest');
-                });
+                return $this->createGuard($app, $auth, $config);
             });
         });
     }
@@ -105,15 +103,18 @@ class SanctumServiceProvider extends ServiceProvider
     /**
      * Register the guard.
      *
-     * @param \Illuminate\Contracts\Auth\Factory  $auth
-     * @param array $config
+     * @param  \Illuminate\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Auth\Factory  $auth
+     * @param  array  $config
      * @return RequestGuard
      */
-    protected function createGuard($auth, $config)
+    protected function createGuard($app, $auth, $config)
     {
         return new RequestGuard(
             new Guard($auth, config('sanctum.expiration'), $config['provider']),
-            $this->app['request'],
+            function () use ($app) {
+                return $app->make('request');
+            },
             $auth->createUserProvider($config['provider'] ?? null)
         );
     }

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -189,7 +189,9 @@ class GuardTest extends TestCase
             'token' => hash('sha256', 'test'),
         ]);
 
-        $returnedUser = $requestGuard->setRequest($request)->user();
+        $returnedUser = $requestGuard->setRequestResolver(function () use ($request) {
+            return $request;
+        })->user();
 
         $this->assertNull($returnedUser);
         $this->assertInstanceOf(EloquentUserProvider::class, $requestGuard->getProvider());
@@ -223,7 +225,9 @@ class GuardTest extends TestCase
             'token' => hash('sha256', 'test'),
         ]);
 
-        $returnedUser = $requestGuard->setRequest($request)->user();
+        $returnedUser = $requestGuard->setRequestResolver(function () use ($request) {
+            return $request;
+        })->user();
 
         $this->assertEquals($user->id, $returnedUser->id);
         $this->assertInstanceOf(EloquentUserProvider::class, $requestGuard->getProvider());


### PR DESCRIPTION
Instead of injecting the request from the container and using a rebinding callback - inject a closure that always resolves the current request.