### PR TITLE
[2.x] Add HasApiTokens contract to complement trait

### DIFF
--- a/src/Contracts/HasApiTokens.php
+++ b/src/Contracts/HasApiTokens.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Laravel\Sanctum\Contracts;
 
 interface HasApiTokens
@@ -41,7 +39,7 @@ interface HasApiTokens
      * Set the current access token for the user.
      *
      * @param  \Laravel\Sanctum\Contracts\HasAbilities  $accessToken
-     * @return HasApiTokens
+     * @return \Laravel\Sanctum\Contracts\HasApiTokens
      */
     public function withAccessToken($accessToken);
 }

--- a/src/Contracts/HasApiTokens.php
+++ b/src/Contracts/HasApiTokens.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Sanctum\Contracts;
+
+interface HasApiTokens
+{
+    /**
+     * Get the access tokens that belong to model.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function tokens();
+
+    /**
+     * Determine if the current API token has a given scope.
+     *
+     * @param  string  $ability
+     * @return bool
+     */
+    public function tokenCan(string $ability);
+
+    /**
+     * Create a new personal access token for the user.
+     *
+     * @param  string  $name
+     * @param  array  $abilities
+     * @return \Laravel\Sanctum\NewAccessToken
+     */
+    public function createToken(string $name, array $abilities = ['*']);
+
+    /**
+     * Get the access token currently associated with the user.
+     *
+     * @return \Laravel\Sanctum\Contracts\HasAbilities
+     */
+    public function currentAccessToken();
+
+    /**
+     * Set the current access token for the user.
+     *
+     * @param  \Laravel\Sanctum\Contracts\HasAbilities  $accessToken
+     * @return HasApiTokens
+     */
+    public function withAccessToken($accessToken);
+}

--- a/tests/ActingAsTest.php
+++ b/tests/ActingAsTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Sanctum\Tests;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
+use Laravel\Sanctum\Contracts\HasApiTokens as HasApiTokensContract;
 use Laravel\Sanctum\HasApiTokens;
 use Laravel\Sanctum\Sanctum;
 use Laravel\Sanctum\SanctumServiceProvider;
@@ -96,7 +97,7 @@ class ActingAsTest extends TestCase
     }
 }
 
-class SanctumUser extends User
+class SanctumUser extends User implements HasApiTokensContract
 {
     use HasApiTokens;
 }

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Laravel\Sanctum\Contracts\HasApiTokens as HasApiTokensContract;
 use Laravel\Sanctum\Guard;
 use Laravel\Sanctum\HasApiTokens;
 use Laravel\Sanctum\PersonalAccessToken;
@@ -235,7 +236,7 @@ class GuardTest extends TestCase
     }
 }
 
-class User extends Model
+class User extends Model implements HasApiTokensContract
 {
     use HasApiTokens;
 }

--- a/tests/HasApiTokensTest.php
+++ b/tests/HasApiTokensTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Sanctum\Tests;
 
+use Laravel\Sanctum\Contracts\HasApiTokens as HasApiTokensContract;
 use Laravel\Sanctum\HasApiTokens;
 use Laravel\Sanctum\PersonalAccessToken;
 use Laravel\Sanctum\TransientToken;
@@ -38,7 +39,7 @@ class HasApiTokensTest extends TestCase
     }
 }
 
-class ClassThatHasApiTokens
+class ClassThatHasApiTokens implements HasApiTokensContract
 {
     use HasApiTokens;
 


### PR DESCRIPTION
In a recent project using Sanctum I wanted to check if the `User`/`Model`/`Authenticatable`/whatever uses the `HasApiTokens` trait. Currently this can only be achieved by one of the following options:

```php
// A. check trait usage
if (! in_array(HasApiTokens::class, class_uses($user)) {
    throw new Exception();
}

// B. check method existence
if (! method_exists($user, 'currentAccessToken')) {
    throw new Exception();
}
```

* Option A will work, but static analysis will not understand that `$user` has a specific set of methods.
* Option B does support static analysis, but is messy, because it doesn't really check for the trait (or specific contract).

Therefore I've added a contract to complement the trait.

```php
use Laravel\Sanctum\Contracts\HasApiTokens as HasApiTokensContract;

if (! $user instanceof HasApiTokensContract::class) {
    throw new Exception();
}
```

This contract is not required for general use of Sanctum and is not a breaking change.
