### PR TITLE
More granular control over token validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/laravel/sanctum/compare/v2.10.0...2.x)
 ### Added
-- `Sanctum::$validateCallback` callback for more granular control over access token validation
+- `Sanctum::$validateCallback` callback for more granular control over access token validation ([#275](https://github.com/laravel/sanctum/pull/275))
 
 ## [v2.10.0 (2021-04-20)](https://github.com/laravel/sanctum/compare/v2.9.4...v2.10.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release Notes
 
 ## [Unreleased](https://github.com/laravel/sanctum/compare/v2.10.0...2.x)
-
+### Added
+- `Sanctum::$validateCallback` callback for more granular control over access token validation
 
 ## [v2.10.0 (2021-04-20)](https://github.com/laravel/sanctum/compare/v2.9.4...v2.10.0)
 

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -65,7 +65,7 @@ class Guard
 
             $accessToken = $model::findToken($token);
 
-            if (!$this->isValidAccessToken($accessToken)) {
+            if (! $this->isValidAccessToken($accessToken)) {
                 return;
             }
 

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -113,12 +113,12 @@ class Guard
      */
     protected function isValidAccessToken($accessToken): bool
     {
-        if (!$accessToken) {
+        if (! $accessToken) {
             return false;
         }
 
         $is_valid =
-            (!$this->expiration || $accessToken->created_at->gt(now()->subMinutes($this->expiration)))
+            (! $this->expiration || $accessToken->created_at->gt(now()->subMinutes($this->expiration)))
             && $this->hasValidProvider($accessToken->tokenable);
 
         if (is_callable(Sanctum::$validateCallback)) {

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -113,10 +113,13 @@ class Guard
      */
     protected function isValidAccessToken($accessToken): bool
     {
-        $is_valid = $accessToken && (
-                ($this->expiration && $accessToken->created_at->gt(now()->subMinutes($this->expiration)))
-                || $this->hasValidProvider($accessToken->tokenable)
-            );
+        if (!$accessToken) {
+            return false;
+        }
+
+        $is_valid =
+            (!$this->expiration || $accessToken->created_at->gt(now()->subMinutes($this->expiration)))
+            && $this->hasValidProvider($accessToken->tokenable);
 
         if (is_callable(Sanctum::$validateCallback)) {
             $is_valid = (bool) (Sanctum::$validateCallback)($accessToken, $is_valid);

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -21,6 +21,16 @@ class Sanctum
     public static $runsMigrations = true;
 
     /**
+     * A callback that can add to the validation of the access token.
+     * Receives 2 parameters:
+     * - (object) The provided access token model.
+     * - (bool) Whether the guard deemed the access token valid.
+     *
+     * @var callable|null
+     */
+    public static $validateCallback = null;
+
+    /**
      * Set the current user for the application with the given abilities.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|\Laravel\Sanctum\HasApiTokens  $user

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -28,7 +28,7 @@ class Sanctum
      *
      * @var callable|null
      */
-    public static $validateCallback = null;
+    public static $validateCallback;
 
     /**
      * Set the current user for the application with the given abilities.

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -259,11 +259,11 @@ class GuardTest extends TestCase
             'token' => hash('sha256', 'test'),
         ]);
 
-        Sanctum::$validateCallback = function($accessToken, bool $is_valid) {
-          $this->assertInstanceOf(PersonalAccessToken::class, $accessToken);
-          $this->assertTrue($is_valid);
+        Sanctum::$validateCallback = function ($accessToken, bool $is_valid) {
+            $this->assertInstanceOf(PersonalAccessToken::class, $accessToken);
+            $this->assertTrue($is_valid);
 
-          return false;
+            return false;
         };
 
         $user = $requestGuard->setRequest($request)->user();


### PR DESCRIPTION
## Reason for this feature
Currently Sanctum has a bit of a shotgun approach to validation. You either specify: 
1. how long *all tokens* are valid
2. they are *all* valid forever
 
There is no easy user control for overwriting this behavior.

By implementing this feature developers are able to make:
- Single use tokens
- Limited time tokens & unlimited time tokens at the same time
- Use any other business logic that prevents a specific user from being able to use that token

## Usage
The `Guard` now checks for a validation callback on the `Sanctum` class. This callback receives:
- The used access token
- The current validation state (`bool`) according to the `Guard`

To make a **single use token** you can to this for instance:

```php
// AppServiceProvider.php
use Laravel\Sanctum\PersonalAccessToken
use Laravel\Sanctum\Sanctum;

public function boot()
{
    // ...
    
    Sanctum::$validateCallback = static function ($accessToken, bool $is_valid) {
        if (!$is_valid || !$accessToken instanceof PersonalAccessToken) {
            return $is_valid; // keep regular behavior
        }

        return $accessToken->last_used_at === null;
    };
}
```

Since `Sanctum::$validateCallback` is expected to be a callable, you can replace it with a service from the container if you need to, or make an `__invoke()`-able class, or a combination of the two.

And because the `Guard` checks if the `callable` is set, this does not cause any breaking changes.


## Alternative
I first thought about introducing 2 events that could aid in these situations. One to overwrite the validation much like this `callable` is doing. And one after the `Guard` validates the token, so some action can be taken to invalidate them; when the business logic is something funky (probably in combination with a custom `Sanctum::$personalAccessTokenModel` setting).

But I changed my mind because the feature this PR adds is more `final` as it where. Using events opens the door to other packages that start adding validation logic on top of one another, and I feel like this is something the developer needs to control. Not some behind the scenes magic.

It also made more sense to me in the current style of the package. Much like overwriting the `PersonalAccessToken` model on the `Sanctum` class.

