### PR TITLE
Revert removal is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/laravel/sanctum/compare/v2.10.0...2.x)
 
 ### Added
-- `Sanctum::$validateCallback` callback for more granular control over access token validation ([#275](https://github.com/laravel/sanctum/pull/275))
+- `Sanctum::$accessTokenAuthenticationCallback` callback for more granular control over access token validation ([#275](https://github.com/laravel/sanctum/pull/275))
 
 
 ## [v2.10.0 (2021-04-20)](https://github.com/laravel/sanctum/compare/v2.9.4...v2.10.0)

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -104,7 +104,7 @@ class Guard
             (! $this->expiration || $accessToken->created_at->gt(now()->subMinutes($this->expiration)))
             && $this->hasValidProvider($accessToken->tokenable);
 
-        if ($isValid && is_callable(Sanctum::$accessTokenAuthenticationCallback)) {
+        if (is_callable(Sanctum::$accessTokenAuthenticationCallback)) {
             $isValid = (bool) (Sanctum::$accessTokenAuthenticationCallback)($accessToken, $isValid);
         }
 

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -105,7 +105,7 @@ class Guard
             && $this->hasValidProvider($accessToken->tokenable);
 
         if ($isValid && is_callable(Sanctum::$accessTokenAuthenticationCallback)) {
-            $isValid = (bool) (Sanctum::$accessTokenAuthenticationCallback)($accessToken);
+            $isValid = (bool) (Sanctum::$accessTokenAuthenticationCallback)($accessToken, $isValid);
         }
 
         return $isValid;

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -259,8 +259,9 @@ class GuardTest extends TestCase
             'token' => hash('sha256', 'test'),
         ]);
 
-        Sanctum::authenticateAccessTokensUsing(function ($accessToken) {
+        Sanctum::authenticateAccessTokensUsing(function ($accessToken, bool $isValid) {
             $this->assertInstanceOf(PersonalAccessToken::class, $accessToken);
+            $this->assertTrue($isValid);
 
             return false;
         });


### PR DESCRIPTION
As a follow up to #275 and because of the comment @driesvints made on that PR:

> @doekenorg best that you send a follow up pr as its unlikely that Taylor will see your reply

I noticed you removed the `$isValid` parameter from the callback in your reformatting. Any particular reason you did this? I would like to ask to revert that because now I cannot actually **add** to the validation, but only **completely replace it**. If I don't know if the `Guard` deemed it valid I need to check those validations again myself inside the callback; which is a bit of a pain.

Say I want to use the normal behavior, but only use the token one time, I now have to re-add the checks to see if the token hasn't expired already. This seems a bit counter productive to me. It can even make the validation less secure, because If iI only implemented a check to see if the token hasn't been used before, I can potentially use a token that has expired long ago.

