### PR TITLE
Only parse `APP_URL` for default stateful domains when it's set

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -13,10 +13,11 @@ return [
     |
     */
 
-    'stateful' => explode(',', env(
-        'SANCTUM_STATEFUL_DOMAINS',
-        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1,'.parse_url(env('APP_URL'), PHP_URL_HOST)
-    )),
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        env('APP_URL') ? ','.parse_url(env('APP_URL'), PHP_URL_HOST) : ''
+    ))),
 
     /*
     |--------------------------------------------------------------------------

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,9 +10,6 @@
          processIsolation="false"
          stopOnFailure="false"
 >
-    <php>
-        <env name="APP_URL" value="https://www.test.com"/>
-    </php>
     <testsuites>
         <testsuite name="Sanctum Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/tests/DefaultConfigContainsAppUrlTest.php
+++ b/tests/DefaultConfigContainsAppUrlTest.php
@@ -8,11 +8,12 @@ use Orchestra\Testbench\TestCase;
 
 class DefaultConfigContainsAppUrlTest extends TestCase
 {
-    protected function useDefaultStatefulConfiguration($app)
+    protected function getEnvironmentSetUp($app)
     {
+        putenv('APP_URL=https://www.example.com');
         $config = require __DIR__.'/../config/sanctum.php';
 
-        $app->config->set('sanctum.stateful', $config['stateful']);
+        $app['config']->set('sanctum.stateful', $config['stateful']);
     }
 
     public function test_default_config_contains_app_url()
@@ -24,12 +25,20 @@ class DefaultConfigContainsAppUrlTest extends TestCase
         $this->assertContains($app_host, $config['stateful']);
     }
 
-    /**
-     * @environment-setup useDefaultStatefulConfiguration
-     */
+    public function test_app_url_is_not_parsed_when_missing_from_env()
+    {
+        putenv('APP_URL');
+
+        $config = require __DIR__.'/../config/sanctum.php';
+
+        $this->assertNull(env('APP_URL'));
+        $this->assertNotContains('', $config['stateful']);
+    }
+
     public function test_request_from_app_url_is_stateful_with_default_config()
     {
         $request = Request::create('/');
+
         $request->headers->set('referer', env('APP_URL'));
 
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));


### PR DESCRIPTION
#### Problem
If `APP_URL` is *not* defined in the .env, the config breaks on PHP 8.1 with a null string deprecation. Since it has to load in the service provider, artisan and composer are broken too (not sure about new installs though—I only have 8.1 via GH actions).

For older versions, it's less of an issue - it merely adds `''` to the `sanctum.stateful` array. Looks scary from a distance, but there's an `array_filter()` in the middleware so it's harmless... I think.

**Introduced in v2.9.3** via #264.

#### Notes
A simple `env('APP_URL', '')` would suffice for the 8.1 issue, but it still leaves the extra empty entry in `sanctum.stateful`. To remove any chance of worry/risk/ambiguity, this PR makes the whole thing conditional on `APP_URL` being defined.