### PR TITLE
Ignore updating `last_used_at` for deciding the DB connection host

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -70,7 +70,7 @@ class Guard
             }
 
             return $this->supportsTokens($accessToken->tokenable) ? $accessToken->tokenable->withAccessToken(
-                tap($accessToken->forceFill(['last_used_at' => now()]))->save()
+                $accessToken->updateLastUsedAt()
             ) : null;
         }
     }

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -70,11 +70,16 @@ class Guard
                 return;
             }
 
-            tap($accessToken->getConnection()->hasModifiedRecords(), function ($hasModifiedRecords) use ($accessToken) {
-                $accessToken->forceFill(['last_used_at' => now()])->save();
+            if (method_exists($accessToken->getConnection(), 'hasModifiedRecords') &&
+                method_exists($accessToken->getConnection(), 'recordsHaveBeenModified')) {
+                tap($accessToken->getConnection()->hasModifiedRecords(), function ($hasModifiedRecords) use ($accessToken) {
+                    $accessToken->forceFill(['last_used_at' => now()])->save();
 
-                $accessToken->getConnection()->recordsHaveBeenModified($hasModifiedRecords);
-            });
+                    $accessToken->getConnection()->recordsHaveBeenModified($hasModifiedRecords);
+                });
+            } else {
+                $accessToken->forceFill(['last_used_at' => now()])->save();
+            }
 
             return $accessToken->tokenable->withAccessToken(
                 $accessToken

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -88,4 +88,19 @@ class PersonalAccessToken extends Model implements HasAbilities
     {
         return ! $this->can($ability);
     }
+
+    /**
+     * Update last_used_at timestamp
+     *
+     * @return $this
+     */
+    public function updateLastUsedAt()
+    {
+        $this->forceFill(['last_used_at' => now()]);
+        $accessToken = $this;
+        app()->terminating(function () use ($accessToken) {
+            $accessToken->save();
+        });
+        return $this;
+    }
 }

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -90,7 +90,7 @@ class PersonalAccessToken extends Model implements HasAbilities
     }
 
     /**
-     * Update last_used_at timestamp
+     * Update the `last_used_at` timestamp and save in the application termination.
      *
      * @return $this
      */

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -75,7 +75,7 @@ class PersonalAccessToken extends Model implements HasAbilities
     public function can($ability)
     {
         return in_array('*', $this->abilities) ||
-               array_key_exists($ability, array_flip($this->abilities));
+            array_key_exists($ability, array_flip($this->abilities));
     }
 
     /**
@@ -86,7 +86,7 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public function cant($ability)
     {
-        return ! $this->can($ability);
+        return !$this->can($ability);
     }
 
     /**
@@ -96,7 +96,7 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public function updateLastUsedAt()
     {
-        $this->forceFill(['last_used_at' => now()]);
+        $this->last_used_at = now();
         $accessToken = $this;
         app()->terminating(function () use ($accessToken) {
             $accessToken->save();

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -88,20 +88,4 @@ class PersonalAccessToken extends Model implements HasAbilities
     {
         return ! $this->can($ability);
     }
-
-    /**
-     * Update the `last_used_at` timestamp and save in the application termination.
-     *
-     * @return $this
-     */
-    public function updateLastUsedAt()
-    {
-        $this->last_used_at = now();
-        $accessToken = $this;
-        app()->terminating(function () use ($accessToken) {
-            $accessToken->save();
-        });
-
-        return $this;
-    }
 }

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -101,6 +101,7 @@ class PersonalAccessToken extends Model implements HasAbilities
         app()->terminating(function () use ($accessToken) {
             $accessToken->save();
         });
+        
         return $this;
     }
 }

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -75,7 +75,7 @@ class PersonalAccessToken extends Model implements HasAbilities
     public function can($ability)
     {
         return in_array('*', $this->abilities) ||
-               array_key_exists($ability, array_flip($this->abilities));
+            array_key_exists($ability, array_flip($this->abilities));
     }
 
     /**
@@ -86,7 +86,7 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public function cant($ability)
     {
-        return ! $this->can($ability);
+        return !$this->can($ability);
     }
 
     /**
@@ -101,7 +101,7 @@ class PersonalAccessToken extends Model implements HasAbilities
         app()->terminating(function () use ($accessToken) {
             $accessToken->save();
         });
-        
+
         return $this;
     }
 }

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -75,7 +75,7 @@ class PersonalAccessToken extends Model implements HasAbilities
     public function can($ability)
     {
         return in_array('*', $this->abilities) ||
-            array_key_exists($ability, array_flip($this->abilities));
+               array_key_exists($ability, array_flip($this->abilities));
     }
 
     /**
@@ -86,7 +86,7 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public function cant($ability)
     {
-        return !$this->can($ability);
+        return ! $this->can($ability);
     }
 
     /**


### PR DESCRIPTION
**Problem**
Sanctum updates the access token's `last_used_at` property every time an API is authenticated using sanctum guard. This db query happens in the initial phase of the request cycle. This causes all the subsequent db queries to go to writer host even in the case of read operations.

**Solution**
Saving the updated `last_used_at` operation is moved to the application terminating event. 
