### PR TITLE
Resolving wrong app instance on Octane

### DIFF
--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -26,7 +26,7 @@ class SanctumServiceProvider extends ServiceProvider
             ], config('auth.guards.sanctum', [])),
         ]);
 
-        if (! $this->app->configurationIsCached()) {
+        if (! app()->configurationIsCached()) {
             $this->mergeConfigFrom(__DIR__.'/../config/sanctum.php', 'sanctum');
         }
     }
@@ -38,7 +38,7 @@ class SanctumServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if ($this->app->runningInConsole()) {
+        if (app()->runningInConsole()) {
             $this->registerMigrations();
 
             $this->publishes([
@@ -74,7 +74,7 @@ class SanctumServiceProvider extends ServiceProvider
      */
     protected function defineRoutes()
     {
-        if ($this->app->routesAreCached() || config('sanctum.routes') === false) {
+        if (app()->routesAreCached() || config('sanctum.routes') === false) {
             return;
         }
 
@@ -95,8 +95,8 @@ class SanctumServiceProvider extends ServiceProvider
     {
         Auth::resolved(function ($auth) {
             $auth->extend('sanctum', function ($app, $name, array $config) use ($auth) {
-                return tap($this->createGuard($auth, $config), function ($guard) use ($app) {
-                    $app->refresh('request', $guard, 'setRequest');
+                return tap($this->createGuard($auth, $config), function ($guard) {
+                    app()->refresh('request', $guard, 'setRequest');
                 });
             });
         });
@@ -113,7 +113,7 @@ class SanctumServiceProvider extends ServiceProvider
     {
         return new RequestGuard(
             new Guard($auth, config('sanctum.expiration'), $config['provider']),
-            $this->app['request'],
+            app()['request'],
             $auth->createUserProvider($config['provider'] ?? null)
         );
     }
@@ -125,7 +125,7 @@ class SanctumServiceProvider extends ServiceProvider
      */
     protected function configureMiddleware()
     {
-        $kernel = $this->app->make(Kernel::class);
+        $kernel = app()->make(Kernel::class);
 
         $kernel->prependToMiddlewarePriority(EnsureFrontendRequestsAreStateful::class);
     }

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -95,8 +95,8 @@ class SanctumServiceProvider extends ServiceProvider
     {
         Auth::resolved(function ($auth) {
             $auth->extend('sanctum', function ($app, $name, array $config) use ($auth) {
-                return tap($this->createGuard($auth, $config), function ($guard) {
-                    app()->refresh('request', $guard, 'setRequest');
+                return tap($this->createGuard($auth, $config), function ($guard) use ($app) {
+                    $app->refresh('request', $guard, 'setRequest');
                 });
             });
         });


### PR DESCRIPTION
In `SanctumServiceProvider` some places it was taking instance by `$this->app` which was giving the wrong app instance in the Octane environment.

![image](https://user-images.githubusercontent.com/26340814/121731431-8e298b00-cb0e-11eb-9433-28f6c007907e.png)

it was `spl_object_hash` of different app instances