### PR TITLE
fix: replace hardcoded "web" guard by config('sanctum.guard')

### DIFF
--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -82,7 +82,7 @@ class SanctumServiceProvider extends ServiceProvider
             Route::get(
                 '/csrf-cookie',
                 CsrfCookieController::class.'@show'
-            )->middleware('web');
+            )->middleware(config('sanctum.guard', 'web'));
         });
     }
 


### PR DESCRIPTION
Replace hardcoded "web" guard by config('sanctum.guard') (same as here : https://github.com/laravel/sanctum/blob/2.x/src/Guard.php#L55 )