### PR TITLE
Revert "fix: replace hardcoded "web" guard by config('sanctum.guard')"

### DIFF
--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -82,7 +82,7 @@ class SanctumServiceProvider extends ServiceProvider
             Route::get(
                 '/csrf-cookie',
                 CsrfCookieController::class.'@show'
-            )->middleware(config('sanctum.guard', 'web'));
+            )->middleware('web');
         });
     }
 


### PR DESCRIPTION
Reverts laravel/sanctum#307

The line that was changed references a middleware group, not a guard.