### PR TITLE
Fire Authenticated event with successful bearer token login

### DIFF
--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -4,7 +4,9 @@ namespace Laravel\Sanctum\Tests;
 
 use DateTimeInterface;
 use Illuminate\Auth\EloquentUserProvider;
+use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -42,7 +44,7 @@ class GuardTest extends TestCase
     {
         $factory = Mockery::mock(AuthFactory::class);
 
-        $guard = new Guard($factory, null, 'users');
+        $guard = new Guard('api', $factory, null, 'users');
 
         $webGuard = Mockery::mock(stdClass::class);
 
@@ -64,7 +66,7 @@ class GuardTest extends TestCase
 
         $factory = Mockery::mock(AuthFactory::class);
 
-        $guard = new Guard($factory, null, 'users');
+        $guard = new Guard('api', $factory, null, 'users');
 
         $webGuard = Mockery::mock(stdClass::class);
 
@@ -89,7 +91,7 @@ class GuardTest extends TestCase
 
         $factory = Mockery::mock(AuthFactory::class);
 
-        $guard = new Guard($factory, 1, 'users');
+        $guard = new Guard('api', $factory, 1, 'users');
 
         $webGuard = Mockery::mock(stdClass::class);
 
@@ -129,7 +131,8 @@ class GuardTest extends TestCase
 
         $factory = Mockery::mock(AuthFactory::class);
 
-        $guard = new Guard($factory, null);
+        $guard = new Guard('api', $factory, null);
+        $guard->setDispatcher($events = Mockery::mock(Dispatcher::class));
 
         $webGuard = Mockery::mock(stdClass::class);
 
@@ -138,6 +141,8 @@ class GuardTest extends TestCase
                 ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
+
+        $events->shouldReceive('dispatch')->once()->with(Mockery::type(Authenticated::class));
 
         $request = Request::create('/', 'GET');
         $request->headers->set('Authorization', 'Bearer test');


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull-request solves https://github.com/laravel/sanctum/issues/304, by firing the Authenticated event when authenticating successfully via bearer token without session. 

My motivation for this was so that I could set user context in integrations using an event-driven approach:

```php
Event::listen(Authenticated::class, function (Authenticated $event) {
    Log::driver()->withContext([
        'user_id' => $event->user->getAuthIdentifier(),
    ]);
});
```

As opposed to using a middleware approach:

```php
class SetIntegrationContext
{
    public function handle(Request $request, \Closure $next)
    {
        if ($user = $request->user()) {
            FooIntegration::setUser([
                'id' => $user->getAuthIdentifier(),
            ]);
        }

        return $next($request);
    }
}
```

As I submit this though, I do wonder:

1. Does this introduce inconsistency, as packages like Passport don't dispatch the same event?
2. In a similar way, does this introduce inconsistency by not dispatching Attempting/Failed events when validating Bearer tokens and Logout events when revoking access tokens?