### PR TITLE
feat: add custom fetch token option #325

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -62,4 +62,25 @@ return [
         'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
     ],
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom fetch token
+    |--------------------------------------------------------------------------
+    |
+    | Leaving this as `null` will default to fetching the token from the
+    | `Authorization` header as bearer tokens. If your token should be in other
+    | parts of the request, you may change this to a function
+    | receiving the request:
+    |
+    |  ```php
+
+    |  'fetchToken' => function (Request $request) {
+    |      return $request->query('token'); // E.g: retrieve token as query param
+    |  }
+    |  ```
+    |
+    */
+
+    'fetchToken' => null
 ];

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -29,19 +29,28 @@ class Guard
      */
     protected $provider;
 
+
+    /**
+     * How we retrieve the token for the request
+     */
+    protected $fetchToken;
     /**
      * Create a new guard instance.
      *
      * @param  \Illuminate\Contracts\Auth\Factory  $auth
      * @param  int  $expiration
      * @param  string  $provider
+     * @param  callable $fetchToken
      * @return void
      */
-    public function __construct(AuthFactory $auth, $expiration = null, $provider = null)
+    public function __construct(AuthFactory $auth, $expiration = null, $provider = null, $fetchToken = null)
     {
         $this->auth = $auth;
         $this->expiration = $expiration;
         $this->provider = $provider;
+        $this->fetchToken = $fetchToken ?? function (Request $request) {
+            return $request->bearerToken();
+        };;
     }
 
     /**
@@ -60,7 +69,7 @@ class Guard
             }
         }
 
-        if ($token = $request->bearerToken()) {
+        if ($token = ($this->fetchToken)($request)) {
             $model = Sanctum::$personalAccessTokenModel;
 
             $accessToken = $model::findToken($token);

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -112,7 +112,7 @@ class SanctumServiceProvider extends ServiceProvider
     protected function createGuard($auth, $config)
     {
         return new RequestGuard(
-            new Guard($auth, config('sanctum.expiration'), $config['provider']),
+            new Guard($auth, config('sanctum.expiration'), $config['provider'], config('sanctum.fetchToken')),
             request(),
             $auth->createUserProvider($config['provider'] ?? null)
         );


### PR DESCRIPTION
The rationale behind this commit is to offer a configurable way to obtain the sanctum token from the request so as to broaden the functionality of this package to other scenarios. In my case, this package would fit very well for webhooks authentication and authorization. However, webhooks as you know can't be expected to have any kind of headers.

@driesvints This should be a draft of what I mean. In essence it makes configurable how the token is retrieved from the request. Tests need to be added and your opinion would be much appreciated as I am not PHP/Laravel expert.

About the PR, perhaps should be interesting to make somehow the retrieval of the token configurable on per route basis?