### PR TITLE
Fix the problem that php artisan route:list shows Middleware error when using sanctum

### DIFF
--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -125,8 +125,10 @@ class SanctumServiceProvider extends ServiceProvider
      */
     protected function configureMiddleware()
     {
-        $kernel = app()->make(Kernel::class);
+        if (! app()->runningInConsole()) {
+            $kernel = app()->make(Kernel::class);
 
-        $kernel->prependToMiddlewarePriority(EnsureFrontendRequestsAreStateful::class);
+            $kernel->prependToMiddlewarePriority(EnsureFrontendRequestsAreStateful::class);
+        }
     }
 }


### PR DESCRIPTION
Because SanctumServiceProvider.php incorrectly make Illuminate\Contracts\Http\Kernel in console mode, the error in Middleware of php artisan route:list is displayed as the actual class name(e.g.: \App\Http\Middleware\Authenticate). correct should be the name($routeMiddleware) defined in app/Http/Kernel.php.

What it looks like before using sanctum:
```

+-----------------------------------+------------+
| URI                               | Middleware |
+-----------------------------------+------------+
| web-interface/auth/login          | web        |
|                                   | guest      |
+-----------------------------------+------------+

```

After using sanctum:
```

+-----------------------------------+---------------------------------------------+
| URI                               | Middleware                                  |
+-----------------------------------+---------------------------------------------+
| web-interface/auth/login          | web                                         |
|                                   | App\Http\Middleware\RedirectIfAuthenticated |
+-----------------------------------+---------------------------------------------+

```

Fix:

```

+-----------------------------------+------------+
| URI                               | Middleware |
+-----------------------------------+------------+
| web-interface/auth/login          | web        |
|                                   | guest      |
+-----------------------------------+------------+

```



I added a check for console mode in commit, if in console mode it won't build&make Illuminate\Contracts\Http\Kernel

