### PR TITLE
[2.x] Configurable default token abilities

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -62,4 +62,16 @@ return [
         'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Default Token Abilities
+    |--------------------------------------------------------------------------
+    |
+    | When creating a new token, these abiltiies will be applied if none are
+    | specified. The default behavior is to allow all abilities (*) however,
+    | you are free to change this as needed.
+    |
+    */
+    'default_abilities' => ['*'],
+
 ];

--- a/src/Contracts/HasApiTokens.php
+++ b/src/Contracts/HasApiTokens.php
@@ -26,7 +26,7 @@ interface HasApiTokens
      * @param  array  $abilities
      * @return \Laravel\Sanctum\NewAccessToken
      */
-    public function createToken(string $name, array $abilities = ['*']);
+    public function createToken(string $name, array $abilities = null);
 
     /**
      * Get the access token currently associated with the user.

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -41,12 +41,12 @@ trait HasApiTokens
      * @param  array  $abilities
      * @return \Laravel\Sanctum\NewAccessToken
      */
-    public function createToken(string $name, array $abilities = ['*'])
+    public function createToken(string $name, array $abilities = null)
     {
         $token = $this->tokens()->create([
             'name' => $name,
             'token' => hash('sha256', $plainTextToken = Str::random(40)),
-            'abilities' => $abilities,
+            'abilities' => $abilities ?? config('sanctum.default_abilities', ['*']),
         ]);
 
         return new NewAccessToken($token, $token->getKey().'|'.$plainTextToken);


### PR DESCRIPTION
This PR adds the ability to configure the default abilities new tokens receive. This is achieved with a new `sanctum.default_abilities` config key. If the config is not present it will fall back to the default behavior of `['*']` so that this is not a breaking change.

If the config is already published, adding this key to the existing `sanctum.php` will allow you to configure the default abilities new tokens receive.
