### PR TITLE
allow user update all in one query

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -80,12 +80,12 @@ class Guard
             if (method_exists($accessToken->getConnection(), 'hasModifiedRecords') &&
                 method_exists($accessToken->getConnection(), 'setRecordModificationState')) {
                 tap($accessToken->getConnection()->hasModifiedRecords(), function ($hasModifiedRecords) use ($accessToken) {
-                    $accessToken->forceFill(['last_used_at' => now()])->save();
+                    $accessToken->updateUsedToken(['last_used_at' => now()]);
 
                     $accessToken->getConnection()->setRecordModificationState($hasModifiedRecords);
                 });
             } else {
-                $accessToken->forceFill(['last_used_at' => now()])->save();
+                $accessToken->updateUsedToken(['last_used_at' => now()]);
             }
 
             return $tokenable;

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -88,4 +88,13 @@ class PersonalAccessToken extends Model implements HasAbilities
     {
         return ! $this->can($ability);
     }
+
+    /**
+     * @param array $attributes
+     * @return bool
+     */
+    public function updateUsedToken(array $attributes)
+    {
+        return $this->forceFill($attributes)->save();
+    }
 }


### PR DESCRIPTION
branch 2.x  
no need to test it's not big change.
add function to allow user for update last_used_at with others attributes in one query.
it should be easy for developer  to overwrite method for that.
