### PR TITLE
Use `$this->id()` instead of `$table->bigIncrements('id')` in migration stub.

### DIFF
--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -14,7 +14,7 @@ class CreatePersonalAccessTokensTable extends Migration
     public function up()
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->id();
             $table->morphs('tokenable');
             $table->string('name');
             $table->string('token', 64)->unique();


### PR DESCRIPTION
By default, in the [laravel/laravel](https://github.com/laravel/laravel/blob/9.x/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php#L17) package it's using `$this->id()`, but if i vendor:publish the sanctum package (or install jetstream) the line is overwritten with `$table->bigIncrements('id')` I believe it's better to use `$this->id()` here too.