### PR TITLE
added experiration time after last valid request

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -50,6 +50,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Expiration Minutes after last valid request
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes between validated requests until an issued token will be
+    | considered expired. If this value is null, personal access tokens do
+    | not expire. This won't tweak the lifetime of first-party sessions.
+    |
+    | It can works only if 'expiration' value is null
+    |
+    */
+
+    'intermediate_expiration' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Sanctum Middleware
     |--------------------------------------------------------------------------
     |

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -112,7 +112,7 @@ class SanctumServiceProvider extends ServiceProvider
     protected function createGuard($auth, $config)
     {
         return new RequestGuard(
-            new Guard($auth, config('sanctum.expiration'), $config['provider']),
+            new Guard($auth, config('sanctum.expiration'), $config['provider'], config('sanctum.intermediate_expiration')),
             request(),
             $auth->createUserProvider($config['provider'] ?? null)
         );


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
At the moment, it is possible to set the lifetime of the token only from the moment of its creation. I am faced with a situation where it is necessary to extend the lifetime of the token after each successfully validated request.

This proposal introduces a new parameter: 'intermediate_expiration' . If the standard 'expiration' is null, and 'intermediate_expiration' is equal to the value in minutes (for example 10), then after each validated request, the token lifetime will be extended by 10 minutes.


I am sure this is a very useful and important thing, perhaps I did not offer the best solution, but this idea must be considered and implemented, I am sure many developers will support me