### PR TITLE
Added custom auth token header support

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -61,7 +61,7 @@ class Guard
             }
         }
 
-        if ($token = $request->bearerToken()) {
+        if ($token = $this->getTokenFromRequest($request)) {
             $model = Sanctum::$personalAccessTokenModel;
 
             $accessToken = $model::findToken($token);
@@ -90,6 +90,21 @@ class Guard
 
             return $tokenable;
         }
+    }
+
+    /**
+     * Get the token from the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string|null
+     */
+    protected function getTokenFromRequest(Request $request)
+    {
+        if (is_callable(Sanctum::$accessTokenFetcher)) {
+            return (string) (Sanctum::$accessTokenFetcher)($request);
+        }
+
+        return $request->bearerToken();
     }
 
     /**

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -93,21 +93,6 @@ class Guard
     }
 
     /**
-     * Get the token from the request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return string|null
-     */
-    protected function getTokenFromRequest(Request $request)
-    {
-        if (is_callable(Sanctum::$accessTokenFetcher)) {
-            return (string) (Sanctum::$accessTokenFetcher)($request);
-        }
-
-        return $request->bearerToken();
-    }
-
-    /**
      * Determine if the tokenable model supports API tokens.
      *
      * @param  mixed  $tokenable
@@ -118,6 +103,21 @@ class Guard
         return $tokenable && in_array(HasApiTokens::class, class_uses_recursive(
             get_class($tokenable)
         ));
+    }
+
+    /**
+     * Get the token from the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string|null
+     */
+    protected function getTokenFromRequest(Request $request)
+    {
+        if (is_callable(Sanctum::$accessTokenRetrievalCallback)) {
+            return (string) (Sanctum::$accessTokenRetrievalCallback)($request);
+        }
+
+        return $request->bearerToken();
     }
 
     /**

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -96,7 +96,7 @@ class Sanctum
      * @param  callable  $callback
      * @return void
      */
-    public static function getAccessTokensFromRequestUsing(callable $callback)
+    public static function getAccessTokenFromRequestUsing(callable $callback)
     {
         static::$accessTokenRetrievalCallback = $callback;
     }

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -18,7 +18,7 @@ class Sanctum
      *
      * @var callable|null
      */
-    public static $accessTokenFetcher;
+    public static $accessTokenRetrievalCallback;
 
     /**
      * A callback that can add to the validation of the access token.
@@ -91,14 +91,14 @@ class Sanctum
     }
 
     /**
-     * Specify a callback that should be used to fetch the token from the request.
+     * Specify a callback that should be used to fetch the access token from the request.
      *
      * @param  callable  $callback
      * @return void
      */
-    public static function fetchAccessTokenUsing(callable $callback)
+    public static function getAccessTokensFromRequestUsing(callable $callback)
     {
-        static::$accessTokenFetcher = $callback;
+        static::$accessTokenRetrievalCallback = $callback;
     }
 
     /**

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -14,6 +14,13 @@ class Sanctum
     public static $personalAccessTokenModel = 'Laravel\\Sanctum\\PersonalAccessToken';
 
     /**
+     * A callback that can get the token from the request.
+     *
+     * @var callable|null
+     */
+    public static $accessTokenFetcher;
+
+    /**
      * A callback that can add to the validation of the access token.
      *
      * @var callable|null
@@ -81,6 +88,17 @@ class Sanctum
     public static function usePersonalAccessTokenModel($model)
     {
         static::$personalAccessTokenModel = $model;
+    }
+
+    /**
+     * Specify a callback that should be used to fetch the token from the request.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public static function fetchAccessTokenUsing(callable $callback)
+    {
+        static::$accessTokenFetcher = $callback;
     }
 
     /**

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -280,6 +280,139 @@ class GuardTest extends TestCase
 
         $user = $requestGuard->setRequest($request)->user();
         $this->assertNull($user);
+
+        Sanctum::$accessTokenAuthenticationCallback = null;
+    }
+
+    public function test_authentication_is_successful_with_token_in_custom_header()
+    {
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        $factory = Mockery::mock(AuthFactory::class);
+
+        $guard = new Guard($factory, null);
+
+        $webGuard = Mockery::mock(stdClass::class);
+
+        $factory->shouldReceive('guard')
+                ->with('web')
+                ->andReturn($webGuard);
+
+        $webGuard->shouldReceive('user')->once()->andReturn(null);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('X-Auth-Token', 'test');
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
+            'remember_token' => Str::random(10),
+        ]);
+
+        $token = PersonalAccessToken::forceCreate([
+            'tokenable_id' => $user->id,
+            'tokenable_type' => get_class($user),
+            'name' => 'Test',
+            'token' => hash('sha256', 'test'),
+        ]);
+
+        Sanctum::fetchAccessTokenUsing(function (Request $request) {
+            return $request->header('X-Auth-Token');
+        });
+
+        $returnedUser = $guard->__invoke($request);
+
+        $this->assertEquals($user->id, $returnedUser->id);
+        $this->assertEquals($token->id, $returnedUser->currentAccessToken()->id);
+        $this->assertInstanceOf(DateTimeInterface::class, $returnedUser->currentAccessToken()->last_used_at);
+
+        Sanctum::$accessTokenFetcher = null;
+    }
+
+    public function test_authentication_fails_with_token_in_authorization_header_when_using_custom_header()
+    {
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        $factory = Mockery::mock(AuthFactory::class);
+
+        $guard = new Guard($factory, null);
+
+        $webGuard = Mockery::mock(stdClass::class);
+
+        $factory->shouldReceive('guard')
+                ->with('web')
+                ->andReturn($webGuard);
+
+        $webGuard->shouldReceive('user')->once()->andReturn(null);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('Authorization', 'Bearer test');
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
+            'remember_token' => Str::random(10),
+        ]);
+
+        $token = PersonalAccessToken::forceCreate([
+            'tokenable_id' => $user->id,
+            'tokenable_type' => get_class($user),
+            'name' => 'Test',
+            'token' => hash('sha256', 'test'),
+        ]);
+
+        Sanctum::fetchAccessTokenUsing(function (Request $request) {
+            return $request->header('X-Auth-Token');
+        });
+
+        $returnedUser = $guard->__invoke($request);
+
+        $this->assertNull($returnedUser);
+
+        Sanctum::$accessTokenFetcher = null;
+    }
+
+    public function test_authentication_fails_with_token_in_custom_header_when_using_default_authorization_header()
+    {
+        $this->loadLaravelMigrations(['--database' => 'testbench']);
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        $factory = Mockery::mock(AuthFactory::class);
+
+        $guard = new Guard($factory, null);
+
+        $webGuard = Mockery::mock(stdClass::class);
+
+        $factory->shouldReceive('guard')
+                ->with('web')
+                ->andReturn($webGuard);
+
+        $webGuard->shouldReceive('user')->once()->andReturn(null);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('X-Auth-Token', 'test');
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
+            'remember_token' => Str::random(10),
+        ]);
+
+        $token = PersonalAccessToken::forceCreate([
+            'tokenable_id' => $user->id,
+            'tokenable_type' => get_class($user),
+            'name' => 'Test',
+            'token' => hash('sha256', 'test'),
+        ]);
+
+        $returnedUser = $guard->__invoke($request);
+
+        $this->assertNull($returnedUser);
     }
 
     protected function getPackageProviders($app)

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -318,7 +318,7 @@ class GuardTest extends TestCase
             'token' => hash('sha256', 'test'),
         ]);
 
-        Sanctum::fetchAccessTokenUsing(function (Request $request) {
+        Sanctum::getAccessTokensFromRequestUsing(function (Request $request) {
             return $request->header('X-Auth-Token');
         });
 
@@ -328,7 +328,7 @@ class GuardTest extends TestCase
         $this->assertEquals($token->id, $returnedUser->currentAccessToken()->id);
         $this->assertInstanceOf(DateTimeInterface::class, $returnedUser->currentAccessToken()->last_used_at);
 
-        Sanctum::$accessTokenFetcher = null;
+        Sanctum::$accessTokenRetrievalCallback = null;
     }
 
     public function test_authentication_fails_with_token_in_authorization_header_when_using_custom_header()
@@ -365,7 +365,7 @@ class GuardTest extends TestCase
             'token' => hash('sha256', 'test'),
         ]);
 
-        Sanctum::fetchAccessTokenUsing(function (Request $request) {
+        Sanctum::getAccessTokensFromRequestUsing(function (Request $request) {
             return $request->header('X-Auth-Token');
         });
 
@@ -373,7 +373,7 @@ class GuardTest extends TestCase
 
         $this->assertNull($returnedUser);
 
-        Sanctum::$accessTokenFetcher = null;
+        Sanctum::$accessTokenRetrievalCallback = null;
     }
 
     public function test_authentication_fails_with_token_in_custom_header_when_using_default_authorization_header()

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -318,7 +318,7 @@ class GuardTest extends TestCase
             'token' => hash('sha256', 'test'),
         ]);
 
-        Sanctum::getAccessTokensFromRequestUsing(function (Request $request) {
+        Sanctum::getAccessTokenFromRequestUsing(function (Request $request) {
             return $request->header('X-Auth-Token');
         });
 
@@ -365,7 +365,7 @@ class GuardTest extends TestCase
             'token' => hash('sha256', 'test'),
         ]);
 
-        Sanctum::getAccessTokensFromRequestUsing(function (Request $request) {
+        Sanctum::getAccessTokenFromRequestUsing(function (Request $request) {
             return $request->header('X-Auth-Token');
         });
 


### PR DESCRIPTION
I have a use-case with an application where I need to send an authentication token via a different header instead of using the Authorization header due to the app (being a proxy type application) needing to pass the Authorization header in a different capacity.

This pull request adds the capability to Sanctum to specify a different method of getting the token from the request by setting a callback to the Sanctum object, falling back to using the bearer token if nothing has been set.