### PR TITLE
Fix find user by token

### DIFF
--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -56,13 +56,13 @@ class PersonalAccessToken extends Model implements HasAbilities
     public static function findToken($token)
     {
         if (strpos($token, '|') === false) {
-            return static::where('token', hash('sha256', $token))->first();
+            return static::where('token', $token)->first();
         }
 
         [$id, $token] = explode('|', $token, 2);
 
         if ($instance = static::find($id)) {
-            return hash_equals($instance->token, hash('sha256', $token)) ? $instance : null;
+            return hash_equals($instance->token, $token) ? $instance : null;
         }
     }
 

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -303,8 +303,7 @@ class GuardTest extends TestCase
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
-        $request = Request::create('/', 'GET');
-        $request->headers->set('X-Auth-Token', 'test');
+
 
         $user = User::forceCreate([
             'name' => 'Taylor Otwell',
@@ -320,9 +319,14 @@ class GuardTest extends TestCase
             'token' => hash('sha256', 'test'),
         ]);
 
+        $request = Request::create('/', 'GET');
+        $request->headers->set('X-Auth-Token', $token->first()->token);
+
         Sanctum::getAccessTokenFromRequestUsing(function (Request $request) {
             return $request->header('X-Auth-Token');
         });
+
+
 
         $returnedUser = $guard->__invoke($request);
 

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -141,8 +141,7 @@ class GuardTest extends TestCase
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
-        $request = Request::create('/', 'GET');
-        $request->headers->set('Authorization', 'Bearer test');
+
 
         $user = User::forceCreate([
             'name' => 'Taylor Otwell',
@@ -157,6 +156,9 @@ class GuardTest extends TestCase
             'name' => 'Test',
             'token' => hash('sha256', 'test'),
         ]);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('Authorization', 'Bearer '. $token->first()->token);
 
         $returnedUser = $guard->__invoke($request);
 
@@ -180,9 +182,6 @@ class GuardTest extends TestCase
             TokenAuthenticated::class,
         ]);
 
-        $request = Request::create('/', 'GET');
-        $request->headers->set('Authorization', 'Bearer test');
-
         $user = User::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
@@ -196,6 +195,9 @@ class GuardTest extends TestCase
             'name' => 'Test',
             'token' => hash('sha256', 'test'),
         ]);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('Authorization', 'Bearer '. $token->first()->token);
 
         $returnedUser = $requestGuard->setRequest($request)->user();
 
@@ -219,9 +221,6 @@ class GuardTest extends TestCase
             TokenAuthenticated::class,
         ]);
 
-        $request = Request::create('/', 'GET');
-        $request->headers->set('Authorization', 'Bearer test');
-
         $user = User::forceCreate([
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
@@ -235,6 +234,9 @@ class GuardTest extends TestCase
             'name' => 'Test',
             'token' => hash('sha256', 'test'),
         ]);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('Authorization', 'Bearer '. $token->first()->token);
 
         $returnedUser = $requestGuard->setRequest($request)->user();
 


### PR DESCRIPTION
If you try to cache a token when searching for it in the table, then you will not find anything since it will be a completely different token.
And if we implement authorization by token, we will always get null.