### PR TITLE
Allow mock token to access original property and methods

### DIFF
--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -56,7 +56,9 @@ class Sanctum
      */
     public static function actingAs($user, $abilities = [], $guard = 'sanctum')
     {
-        $token = Mockery::mock(self::personalAccessTokenModel())->shouldIgnoreMissing(false);
+        $token = Mockery::mock(self::personalAccessTokenModel())->makePartial();
+        
+        $token->abilities = $abilities;
 
         if (in_array('*', $abilities)) {
             $token->shouldReceive('can')->withAnyArgs()->andReturn(true);


### PR DESCRIPTION
With makePartial the mocked token can access original methods and property.
With this change is possibile to access the abilities properties.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
