### PR TITLE
[3.x] Drop old Laravel and PHP versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,21 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, '8.0', 8.1]
-        laravel: [6, 7, 8, 9]
-        exclude:
-          - php: 7.2
-            laravel: 8
-          - php: 7.2
-            laravel: 9
-          - php: 7.3
-            laravel: 9
-          - php: 7.4
-            laravel: 9
-          - php: 8.1
-            laravel: 6
-          - php: 8.1
-            laravel: 7
+        php: ['8.0', 8.1]
+        laravel: [9]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -14,17 +14,17 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^8.0.2",
         "ext-json": "*",
-        "illuminate/console": "^6.9|^7.0|^8.0|^9.0",
-        "illuminate/contracts": "^6.9|^7.0|^8.0|^9.0",
-        "illuminate/database": "^6.9|^7.0|^8.0|^9.0",
-        "illuminate/support": "^6.9|^7.0|^8.0|^9.0"
+        "illuminate/console": "^9.0",
+        "illuminate/contracts": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/support": "^9.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
-        "phpunit/phpunit": "^8.0|^9.3"
+        "orchestra/testbench": "^7.0",
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In preparation for v3, we'll drop old Laravel and PHP versions and make Laravel v9 and PHP 8.0 the new minimums.