### PR TITLE
Adding abilty to add csrf cookie route name

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -62,4 +62,5 @@ return [
         'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
     ],
 
+    'sanctum.cookie_route_name' => env('SANCTUM_sanctum.cookie_route_name')
 ];

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -82,7 +82,9 @@ class SanctumServiceProvider extends ServiceProvider
             Route::get(
                 '/csrf-cookie',
                 CsrfCookieController::class.'@show'
-            )->middleware('web');
+            )
+                ->middleware('web')
+                ->name(config('sanctum.cookie_route_name'));
         });
     }
 

--- a/tests/DefaultConfigContainsAppUrlTest.php
+++ b/tests/DefaultConfigContainsAppUrlTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Sanctum\Tests;
 
 use Illuminate\Http\Request;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Laravel\Sanctum\SanctumServiceProvider;
 use Orchestra\Testbench\TestCase;
 
 class DefaultConfigContainsAppUrlTest extends TestCase
@@ -42,5 +43,16 @@ class DefaultConfigContainsAppUrlTest extends TestCase
         $request->headers->set('referer', env('APP_URL'));
 
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+    }
+
+    public function test_csrf_cookie_route_can_be_named()
+    {
+        $app = app();
+        $app['config']->set('sanctum.cookie_route_name', 'csrf.token');
+        (new SanctumServiceProvider($app))->boot();
+
+        $app->router->getRoutes()->compile();
+
+        $this->assertTrue($app->router->getRoutes()->hasNamedRoute('csrf.token'));
     }
 }


### PR DESCRIPTION
This PR gives developers the opportunity to add a route name for the csrf-cookie route. When working with an SPA in tandem with something like https://github.com/tighten/ziggy, you can pass route names to a `route` helper function. This will keep it consistent with being able to name other routes in a standard Laravel application.

This adds a new item in the sanctum config which is used in the route name, if it is `null` it is ignored.
