### PR TITLE
Update migration's primary identifier change

### DIFF
--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->id();
             $table->morphs('tokenable');
             $table->string('name');
             $table->string('token', 64)->unique();


### PR DESCRIPTION
This is the migration file in laravel：
`2019_12_14_000001_create_personal_access_tokens_table.php`
```
....
Schema::create('personal_access_tokens', function (Blueprint $table) {
    $table->id();
...
```

This is the migration file in sanctum：
`2019_12_14_000001_create_personal_access_tokens_table.php`
```
...
Schema::create('personal_access_tokens', function (Blueprint $table) {
    $table->bigIncrements('id');
...
```

I think the id field should be kept consistent.