### PR TITLE
Add feature able to custom hash type in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
-.idea

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -49,6 +49,20 @@ return [
     'expiration' => null,
 
     /*
+   |--------------------------------------------------------------------------
+   | Hashing algorithm
+   |--------------------------------------------------------------------------
+   |
+   | Specify the hashing algorithm that will be used to sign the token.
+   |
+   | See here: https://www.php.net/manual/en/function.hash-algos.php
+   | for possible values.
+   |
+   */
+
+    'algo' => env('SANCTUM_TOKEN_ALGO', 'sha256'),
+
+    /*
     |--------------------------------------------------------------------------
     | Sanctum Middleware
     |--------------------------------------------------------------------------

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -47,7 +47,7 @@ trait HasApiTokens
     {
         $token = $this->tokens()->create([
             'name' => $name,
-            'token' => hash('sha256', $plainTextToken = Str::random(40)),
+            'token' => hash(config('sanctum.algo', 'sha256'), $plainTextToken = Str::random(40)),
             'abilities' => $abilities,
             'expires_at' => $expiresAt,
         ]);

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -58,13 +58,13 @@ class PersonalAccessToken extends Model implements HasAbilities
     public static function findToken($token)
     {
         if (strpos($token, '|') === false) {
-            return static::where('token', hash('sha256', $token))->first();
+            return static::where('token', hash(config('sanctum.algo', 'sha256'), $token))->first();
         }
 
         [$id, $token] = explode('|', $token, 2);
 
         if ($instance = static::find($id)) {
-            return hash_equals($instance->token, hash('sha256', $token)) ? $instance : null;
+            return hash_equals($instance->token, hash(config('sanctum.algo', 'sha256'), $token)) ? $instance : null;
         }
     }
 

--- a/tests/HasApiTokensTest.php
+++ b/tests/HasApiTokensTest.php
@@ -36,6 +36,27 @@ class HasApiTokensTest extends TestCase
         );
     }
 
+    public function test_tokens_can_be_created_with_sha512()
+    {
+        config(['sanctum.algo' => 'sha512']);
+
+        $class = new ClassThatHasApiTokens;
+
+        $newToken = $class->createToken('test');
+
+        [$id, $token] = explode('|', $newToken->plainTextToken);
+
+        $this->assertEquals(
+            $newToken->accessToken->token,
+            hash('sha512', $token)
+        );
+
+        $this->assertNotEquals(
+            $newToken->accessToken->token,
+            hash('sha256', $token)
+        );
+    }
+
     public function test_can_check_token_abilities()
     {
         $class = new ClassThatHasApiTokens;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently the default hash algo which is sha256 and unable to customize without extend the method. So, this pull request intended to make the sanctum hash algo customizable in `HasApiTokens` trait and `PersonalAccessToken` model via sanctum config file.

I added algo value in sanctum.php config file and also added test to check the algo changes
