### PR TITLE
add migration file for adding expires_at field

### DIFF
--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -20,7 +20,6 @@ return new class extends Migration
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();
             $table->timestamp('last_used_at')->nullable();
-            $table->timestamp('expires_at')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_08_30_093039_add_expires_at_column_to_personal_access_tokens_table.php
+++ b/database/migrations/2022_08_30_093039_add_expires_at_column_to_personal_access_tokens_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->timestamp('expires_at')->nullable()->after('last_used_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->dropColumn('expires_at');
+        });
+    }
+};


### PR DESCRIPTION
add migration file for adding expires_at field
when upgrading to v3 the record for 2019_12_14_000001_create_personal_access_tokens_table already exists in the migrations table in the DB so it will not add the new column and ignore the modifications for the original migration file