### PR TITLE
feature: added config option to disable handling of bearer tokens

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -37,6 +37,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Bearer Token Handling
+    |--------------------------------------------------------------------------
+    |
+    | This value controls whether Sanctum should use the bearer token that's
+    | present on an incoming request for authentication if none of the Guards
+    | were able to authenticate the it.
+    |
+    */
+
+    'handle_bearer_tokens' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Expiration Minutes
     |--------------------------------------------------------------------------
     |

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -61,7 +61,7 @@ class Guard
             }
         }
 
-        if ($token = $this->getTokenFromRequest($request)) {
+        if (config('sanctum.handle_bearer_tokens', true) && $token = $this->getTokenFromRequest($request)) {
             $model = Sanctum::$personalAccessTokenModel;
 
             $accessToken = $model::findToken($token);


### PR DESCRIPTION
## Description
This pull request adds the ability to disable the default behaviour of Sanctum to interpret bearer tokens in the request header if none of the provided guards were able to authenticate the request.

## Details
Currently, if you ignore Sanctum's database migrations because you want to rely on, for example, a custom Guard which authenticates with a third party auth service instead, and this Guard fails to authenticate the user (e.g. expired/invalid tokens), then
Sanctum will also attempt to validate the Bearer token by itself, which results in a table not found database error.

In order to prevent such issues, we can prevent Sanctum from handling bearer tokens via a config option.

**This change is fully backwards compatible & keeps the current behaviour, unless specifically set to false in the config.**

