### PR TITLE
add missing expiresAt parameter to contract

### DIFF
--- a/src/Contracts/HasApiTokens.php
+++ b/src/Contracts/HasApiTokens.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Sanctum\Contracts;
 
+use DateTimeInterface;
+
 interface HasApiTokens
 {
     /**
@@ -24,9 +26,10 @@ interface HasApiTokens
      *
      * @param  string  $name
      * @param  array  $abilities
+     * @param  \DateTimeInterface|null  $expiresAt
      * @return \Laravel\Sanctum\NewAccessToken
      */
-    public function createToken(string $name, array $abilities = ['*']);
+    public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null);
 
     /**
      * Get the access token currently associated with the user.


### PR DESCRIPTION
This pull request adds the missing expiresAt parameter to the contract. 