### PR TITLE
refactor: early return was used to keep readability

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -61,7 +61,7 @@ class Guard
             }
         }
 
-        if (!$token = $this->getTokenFromRequest($request)) {
+        if (! $token = $this->getTokenFromRequest($request)) {
             return null;
         }
 

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -61,35 +61,37 @@ class Guard
             }
         }
 
-        if ($token = $this->getTokenFromRequest($request)) {
-            $model = Sanctum::$personalAccessTokenModel;
-
-            $accessToken = $model::findToken($token);
-
-            if (! $this->isValidAccessToken($accessToken) ||
-                ! $this->supportsTokens($accessToken->tokenable)) {
-                return;
-            }
-
-            $tokenable = $accessToken->tokenable->withAccessToken(
-                $accessToken
-            );
-
-            event(new TokenAuthenticated($accessToken));
-
-            if (method_exists($accessToken->getConnection(), 'hasModifiedRecords') &&
-                method_exists($accessToken->getConnection(), 'setRecordModificationState')) {
-                tap($accessToken->getConnection()->hasModifiedRecords(), function ($hasModifiedRecords) use ($accessToken) {
-                    $accessToken->forceFill(['last_used_at' => now()])->save();
-
-                    $accessToken->getConnection()->setRecordModificationState($hasModifiedRecords);
-                });
-            } else {
-                $accessToken->forceFill(['last_used_at' => now()])->save();
-            }
-
-            return $tokenable;
+        if (!$token = $this->getTokenFromRequest($request)) {
+            return null;
         }
+
+        $model = Sanctum::$personalAccessTokenModel;
+
+        $accessToken = $model::findToken($token);
+
+        if (! $this->isValidAccessToken($accessToken) ||
+            ! $this->supportsTokens($accessToken->tokenable)) {
+            return;
+        }
+
+        $tokenable = $accessToken->tokenable->withAccessToken(
+            $accessToken
+        );
+
+        event(new TokenAuthenticated($accessToken));
+
+        if (method_exists($accessToken->getConnection(), 'hasModifiedRecords') &&
+            method_exists($accessToken->getConnection(), 'setRecordModificationState')) {
+            tap($accessToken->getConnection()->hasModifiedRecords(), function ($hasModifiedRecords) use ($accessToken) {
+                $accessToken->forceFill(['last_used_at' => now()])->save();
+
+                $accessToken->getConnection()->setRecordModificationState($hasModifiedRecords);
+            });
+        } else {
+            $accessToken->forceFill(['last_used_at' => now()])->save();
+        }
+
+        return $tokenable;
     }
 
     /**


### PR DESCRIPTION
 `Early return` was used to keep readability
