### PR TITLE
Remove the period from the sanctum:prune-expired command

### DIFF
--- a/src/Console/Commands/PruneExpired.php
+++ b/src/Console/Commands/PruneExpired.php
@@ -19,7 +19,7 @@ class PruneExpired extends Command
      *
      * @var string
      */
-    protected $description = 'Prune tokens expired for more than specified number of hours.';
+    protected $description = 'Prune tokens expired for more than specified number of hours';
 
     /**
      * Execute the console command.


### PR DESCRIPTION
None of the default laravel commands appear to have one, this is the odd one out.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
