### PR TITLE
Change `expires_at` to dateTime to allow dates after 2038-01-19

### DIFF
--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();
             $table->timestamp('last_used_at')->nullable();
-            $table->timestamp('expires_at')->nullable();
+            $table->dateTime('expires_at')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Changes the `expires_at` column from `TIMESTAMP`  to `DATETIME` to get around ['The 2038 Problem'](https://en.wikipedia.org/wiki/Year_2038_problem)

If you currently try to save the expires at as a data after _03:14:07 on Tuesday, 19 January 2038_  it will save in a MySQL TIMESTAMP column as `0000-00-00 00:00:00`.

Also on Laravel Passport the `expires_at` is using `DATETIME` so this change would be consistent with that: https://github.com/laravel/passport/blob/11.x/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php#L24

```php
$token = \Laravel\Sanctum\PersonalAccessToken::latest('id')->first();
$token->update(['expires_at' => '2038-12-01 00:00:00']);
dump($token->refresh()->getRawOriginal('expires_at'));

// 0000-00-00 00:00:00
```

Changing the column to DATETIME the same code saves correctly:
```php
Schema::table('personal_access_tokens', function (Illuminate\Database\Schema\Blueprint $table) {
    $table->dateTime('expires_at')->nullable()->change();
});

$token = \Laravel\Sanctum\PersonalAccessToken::latest('id')->first();
$token->update(['expires_at' => '2038-12-01 00:00:00']);
dump($token->refresh()->getRawOriginal('expires_at'));

// 2038-12-01 00:00:00
```