### PR TITLE
Carry through session ENV settings to sanctum middleware

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -42,8 +42,8 @@ class EnsureFrontendRequestsAreStateful
     protected function configureSecureCookieSessions()
     {
         config([
-            'session.http_only' => true,
-            'session.same_site' => 'lax',
+            'session.http_only' => env('SESSION_HTTP_ONLY',true),
+            'session.same_site' => env('SESSION_SAME_SITE','lax'),
         ]);
     }
 


### PR DESCRIPTION
We have unique use cases where we do not want http_only and same_site hardcoded here. We need them to be specific values that we have set in our ENV. 

This change will allow it to pull the values from the ENV if they exist, if not, fallback to the original values. Please consider, thanks!

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
