### PR TITLE
Allow overriding of default api token length by static property

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -47,7 +47,7 @@ trait HasApiTokens
     {
         $token = $this->tokens()->create([
             'name' => $name,
-            'token' => hash('sha256', $plainTextToken = Str::random(40)),
+            'token' => hash('sha256', $plainTextToken = Str::random(static::$apiTokenLength ?? 40)),
             'abilities' => $abilities,
             'expires_at' => $expiresAt,
         ]);

--- a/tests/HasApiTokensTest.php
+++ b/tests/HasApiTokensTest.php
@@ -36,6 +36,20 @@ class HasApiTokensTest extends TestCase
         );
     }
 
+    public function test_tokens_with_custom_length_can_be_created()
+    {
+        $class = new ClassThatHasApiTokensWithCustomLength;
+
+        $newToken = $class->createToken('test');
+
+        [$id, $token] = explode('|', $newToken->plainTextToken);
+
+        $this->assertEquals(
+            30,
+            strlen($token)
+        );
+    }
+
     public function test_can_check_token_abilities()
     {
         $class = new ClassThatHasApiTokens;
@@ -60,4 +74,9 @@ class ClassThatHasApiTokens implements HasApiTokensContract
             }
         };
     }
+}
+
+class ClassThatHasApiTokensWithCustomLength extends ClassThatHasApiTokens
+{
+    protected static int $apiTokenLength = 30;
 }


### PR DESCRIPTION
As follow-up for #390, here's a simpler and more flexible solution to override the default token length of 40. Like this, you could simply place a `$apiTokenLength` static property on your model to set the token length.