### PR TITLE
Add middleware group configuration

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -60,6 +60,7 @@ return [
     */
 
     'middleware' => [
+        'group' => 'web',
         'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
         'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
     ],

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -83,12 +83,14 @@ class SanctumServiceProvider extends ServiceProvider
             return;
         }
 
-        Route::group(['prefix' => config('sanctum.prefix', 'sanctum')], function () {
-            Route::get(
-                '/csrf-cookie',
-                CsrfCookieController::class.'@show'
-            )->middleware('web')->name('sanctum.csrf-cookie');
-        });
+        Route::group([
+            'middleware' => config('sanctum.middleware.group', 'web'),
+            'prefix' => config('sanctum.prefix', 'sanctum'), ], function () {
+                Route::get(
+                    '/csrf-cookie',
+                    CsrfCookieController::class.'@show'
+                )->name('sanctum.csrf-cookie');
+            });
     }
 
     /**


### PR DESCRIPTION
We are trying to build an API-only Laravel with an SPA front-end. When removing the `web` middleware routes we figured out Sanctum expects the `web` middleware to exist and adds the `csrf-cookie` route on this middleware group.

This PR amends that by adding a configuration option to change the middleware group to which the endpoint is added to.