### PR TITLE
[3.x] Fix bearer token format validation

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -117,9 +117,31 @@ class Guard
             return (string) (Sanctum::$accessTokenRetrievalCallback)($request);
         }
 
-        return $request->bearerToken();
+        $token = $request->bearerToken();
+
+        return $this->hasValidBearerTokenFormat($token) ? $token : null;
     }
 
+    /**
+     * Determine if the bearer token has valid format
+     *
+     * @param string|null $token
+     * @return bool
+     */
+    protected function hasValidBearerTokenFormat(string $token = null): bool
+    {
+        if (!is_null($token) && strpos($token, '|') !== false) {
+            $model = new Sanctum::$personalAccessTokenModel;
+            if ($model->getKeyType() === 'int') {
+                [$id, $token] = explode('|', $token, 2);
+
+                return ctype_digit($id) && !empty($token);
+            }
+        }
+
+        return !empty($token);
+    }
+    
     /**
      * Determine if the provided access token is valid.
      *

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -123,25 +123,25 @@ class Guard
     }
 
     /**
-     * Determine if the bearer token has valid format
+     * Determine if the bearer token has valid format.
      *
-     * @param string|null $token
-     * @return bool
+     * @param  string|null  $token
+     * @return  bool
      */
     protected function hasValidBearerTokenFormat(string $token = null): bool
     {
-        if (!is_null($token) && strpos($token, '|') !== false) {
+        if (! is_null($token) && strpos($token, '|') !== false) {
             $model = new Sanctum::$personalAccessTokenModel;
             if ($model->getKeyType() === 'int') {
                 [$id, $token] = explode('|', $token, 2);
 
-                return ctype_digit($id) && !empty($token);
+                return ctype_digit($id) && ! empty($token);
             }
         }
 
-        return !empty($token);
+        return ! empty($token);
     }
-    
+
     /**
      * Determine if the provided access token is valid.
      *

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -126,7 +126,7 @@ class Guard
      * Determine if the bearer token has valid format.
      *
      * @param  string|null  $token
-     * @return  bool
+     * @return bool
      */
     protected function hasValidBearerTokenFormat(string $token = null): bool
     {

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -119,19 +119,20 @@ class Guard
 
         $token = $request->bearerToken();
 
-        return $this->hasValidBearerTokenFormat($token) ? $token : null;
+        return $this->isValidBearerToken($token) ? $token : null;
     }
 
     /**
-     * Determine if the bearer token has valid format.
+     * Determine if the bearer token is in the correct format.
      *
      * @param  string|null  $token
      * @return bool
      */
-    protected function hasValidBearerTokenFormat(string $token = null): bool
+    protected function isValidBearerToken(string $token = null)
     {
-        if (! is_null($token) && strpos($token, '|') !== false) {
+        if (! is_null($token) && str_contains($token, '|')) {
             $model = new Sanctum::$personalAccessTokenModel;
+
             if ($model->getKeyType() === 'int') {
                 [$id, $token] = explode('|', $token, 2);
 

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -560,7 +560,7 @@ class GuardTest extends TestCase
         ];
     }
 }
- 
+
 class User extends Model implements HasApiTokensContract
 {
     use HasApiTokens;


### PR DESCRIPTION
This fixes validation for bearer tokens that contain model id (**1**|xxxxxxxx..).
If you alter this id, then server will return 500 error, because there is no format validation (yes, there is some validation regarding token expiration, and presence of the token at all, but that's not enough).

## How to recreate
Just alter the id param for bearer token. Make it something not a valid integer.
This results 500 Server error response for any Sanctum-protected api endpoint.

(mssql server specific, but I think this can be DB-agnostic):
```
SQLSTATE[42000]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Error converting data type nvarchar to bigint. (SQL: select top 1 * from [personal_access_tokens] where [personal_access_tokens].[id] = 1ABC
```

## Expected value
401 Unauthorized HTTP status

