### PR TITLE
[3.x] PersonalAccessToken::getTokenable() method

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -67,11 +67,11 @@ class Guard
             $accessToken = $model::findToken($token);
 
             if (! $this->isValidAccessToken($accessToken) ||
-                ! $this->supportsTokens($accessToken->tokenable)) {
+                ! $this->supportsTokens($accessToken->getTokenable())) {
                 return;
             }
 
-            $tokenable = $accessToken->tokenable->withAccessToken(
+            $tokenable = $accessToken->getTokenable()->withAccessToken(
                 $accessToken
             );
 
@@ -158,7 +158,7 @@ class Guard
         $isValid =
             (! $this->expiration || $accessToken->created_at->gt(now()->subMinutes($this->expiration)))
             && (! $accessToken->expires_at || ! $accessToken->expires_at->isPast())
-            && $this->hasValidProvider($accessToken->tokenable);
+            && $this->hasValidProvider($accessToken->getTokenable());
 
         if (is_callable(Sanctum::$accessTokenAuthenticationCallback)) {
             $isValid = (bool) (Sanctum::$accessTokenAuthenticationCallback)($accessToken, $isValid);

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -50,6 +50,16 @@ class PersonalAccessToken extends Model implements HasAbilities
     }
 
     /**
+     * Get the tokenable model that the access token belongs to.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function getTokenable()
+    {
+        return $this->tokenable;
+    }
+
+    /**
      * Find the token instance matching the given token.
      *
      * @param  string  $token

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -52,7 +52,7 @@ class PersonalAccessToken extends Model implements HasAbilities
     /**
      * Get the tokenable model that the access token belongs to.
      *
-     * @return \Illuminate\Contracts\Auth\Authenticatable
+     * @return \Laravel\Sanctum\Contracts\HasApiTokens
      */
     public function getTokenable()
     {


### PR DESCRIPTION
This p-r brings `PersonalAccessToken::getTokenable()` method. This opens way to implement custom `getTokenable`.

For example — caching user with tagged cache, that we may flush on User model events.

```php
class PersonalAccessToken extends \Laravel\Sanctum\PersonalAccessToken
{
    public function getTokenable()
    {
        return \Illuminate\Cache\TaggedCache::tags('sanctum')
            ->remember($this->token, now()->addDay(), fn() => $this->tokenable);
    }
}
```