### PR TITLE
Php Doc block: return type fixes in CsrfCookieController

### DIFF
--- a/src/Http/Controllers/CsrfCookieController.php
+++ b/src/Http/Controllers/CsrfCookieController.php
@@ -12,7 +12,7 @@ class CsrfCookieController
      * Return an empty response simply to trigger the storage of the CSRF cookie in the browser.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
     public function show(Request $request)
     {


### PR DESCRIPTION
Php Doc block return type fixes in CsrfCookieController 


<img width="685" alt="image" src="https://user-images.githubusercontent.com/15016564/220883980-266483f0-8373-4749-80fe-dfd22d2508a4.png">
