### PR TITLE
Add missing config example for sanctum routes.

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -64,4 +64,18 @@ return [
         'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Routes
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum adds a route "/sanctum/csrf-cookie" for SPA application to fetch
+    | only cookies. This value controls the route generation and prefix.
+    |
+    */
+
+    'routes' => true,
+
+    'prefix' => '/sanctum',
+
 ];


### PR DESCRIPTION
SanctumServiceProvider has useful config keys but these are not listed in config.php.

https://github.com/laravel/sanctum/blob/4a27cd1fe20dde51b3d4eefa02b2f7dffdb512a3/src/SanctumServiceProvider.php#L82-L91

I included them with default values.

