### PR TITLE
trim whitespaces from the token before validation check

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -117,7 +117,7 @@ class Guard
             return (string) (Sanctum::$accessTokenRetrievalCallback)($request);
         }
 
-        $token = $request->bearerToken();
+        $token = trim($request->bearerToken());
 
         return $this->isValidBearerToken($token) ? $token : null;
     }


### PR DESCRIPTION
Sometimes users accidentally pass sanctum tokens in the request header with leading or trailing white-spaces (two white-spaces between the word "Bearer" and the token), like in:
```
curl  -H 'accept: application/json' -H "Authorization: Bearer  <token>" 
curl  -H 'accept: application/json' -H "Authorization: Bearer <token> " 
```

Currently, this results in an unexpected `401` with `{"message":"Unauthenticated."}` response from the application even though the token is correct. This can confuse the user. In this change tokens from the `$request` with leading or trailing white-spaces should be trimmed such that correct token are accepted and not denied.