### PR TITLE
set session.same_site from config/sessions.php

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -44,7 +44,7 @@ class EnsureFrontendRequestsAreStateful
     {
         config([
             'session.http_only' => true,
-            'session.same_site' => 'lax',
+            'session.same_site' => config("session.same_site", "lax"),
         ]);
     }
 


### PR DESCRIPTION
This change involves enabling developers to set the "same_site" inside the "config/sessions.php" file. This feature will be particularly useful during local development when the backend and frontend are running on different ports on localhost, and the session cannot be set due to the "same_site" attribute being set to "lax". By allowing developers to modify the "same_site" attribute via the configuration file, they can overcome this issue.

Example:

config/session.php:
`'same_site' => 'none'`

Request sent from http://localhost:3000 (vue) to http://localhost:8000 (laravel)

![lax_error](https://user-images.githubusercontent.com/88137868/233801358-27983214-5b2f-498f-ba2f-37f7cf5fe724.jpg)

After this change:

![image](https://user-images.githubusercontent.com/88137868/233801482-e5518e15-698f-42f4-939c-605c85347b26.png)

