### PR TITLE
Add default entry for config.middleware.validate_csrf_token

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -60,6 +60,7 @@ return [
     */
 
     'middleware' => [
+        'validate_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
         'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
         'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
     ],


### PR DESCRIPTION
In [v3.2.4](https://github.com/laravel/sanctum/commit/f5bae6156c760545f368438198327e2609ba7bf1#diff-cd82d3386f54185e67e56acc8c7a1e0c537bbc43aec01f51201701eb9dbaf1a4R53) `config.middleware.validate_csrf_token` was added.

This merge request keeps the `config/sanctum.php` file inline with those changes, otherwise if users are taking advantage of excluding URL's for CSRF validation by declaring them in `App\Http\Middleware\VerifyCsrfToken`, it will not be respected and cause a `CRSF token mismatch.` error.

For users upgrading to v3.2.4, this config value will need to be added manually otherwise they will encounter the same issue as above.