### PR TITLE
Fix return type declaration for currentAccessToken()

### DIFF
--- a/src/Contracts/HasApiTokens.php
+++ b/src/Contracts/HasApiTokens.php
@@ -31,7 +31,7 @@ interface HasApiTokens
     /**
      * Get the access token currently associated with the user.
      *
-     * @return \Laravel\Sanctum\Contracts\HasAbilities
+     * @return \Laravel\Sanctum\PersonalAccessToken|null
      */
     public function currentAccessToken();
 

--- a/src/Contracts/HasApiTokens.php
+++ b/src/Contracts/HasApiTokens.php
@@ -31,7 +31,7 @@ interface HasApiTokens
     /**
      * Get the access token currently associated with the user.
      *
-     * @return \Laravel\Sanctum\PersonalAccessToken|null
+     * @return \Laravel\Sanctum\Contracts\HasAbilities&\Illuminate\Database\Eloquent\Model
      */
     public function currentAccessToken();
 

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -58,7 +58,7 @@ trait HasApiTokens
     /**
      * Get the access token currently associated with the user.
      *
-     * @return \Laravel\Sanctum\PersonalAccessToken|null
+     * @return \Laravel\Sanctum\Contracts\HasAbilities&\Illuminate\Database\Eloquent\Model
      */
     public function currentAccessToken()
     {

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -58,7 +58,7 @@ trait HasApiTokens
     /**
      * Get the access token currently associated with the user.
      *
-     * @return \Laravel\Sanctum\Contracts\HasAbilities
+     * @return \Laravel\Sanctum\PersonalAccessToken|null
      */
     public function currentAccessToken()
     {


### PR DESCRIPTION
This PR fixes the return type declaration in the `currentAccessToken()` method. Previously, it didn't account for the fact that `TransientToken` and `PersonalAccessToken` classes also implement the `HasAbilities` interface, causing an inaccurate return type.

To address this, we've updated the return type using Intersection Types from PHP 8.1. Now, the method correctly indicates that it can return an object that is both an `Illuminate\Database\Eloquent\Model` and implements the `Laravel\Sanctum\Contracts\HasAbilities` interface.