### PR TITLE
A comment was written so as not to show an error saying that the property was not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+/.idea

--- a/src/NewAccessToken.php
+++ b/src/NewAccessToken.php
@@ -5,6 +5,9 @@ namespace Laravel\Sanctum;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 
+/**
+ * @property PersonalAccessToken $accessToken
+ */
 class NewAccessToken implements Arrayable, Jsonable
 {
     /**
@@ -24,13 +27,13 @@ class NewAccessToken implements Arrayable, Jsonable
     /**
      * Create a new access token result.
      *
-     * @param  \Laravel\Sanctum\PersonalAccessToken  $accessToken
-     * @param  string  $plainTextToken
+     * @param \Laravel\Sanctum\PersonalAccessToken $accessToken
+     * @param string                               $plainTextToken
      * @return void
      */
     public function __construct(PersonalAccessToken $accessToken, string $plainTextToken)
     {
-        $this->accessToken = $accessToken;
+        $this->accessToken    = $accessToken;
         $this->plainTextToken = $plainTextToken;
     }
 
@@ -42,7 +45,7 @@ class NewAccessToken implements Arrayable, Jsonable
     public function toArray()
     {
         return [
-            'accessToken' => $this->accessToken,
+            'accessToken'    => $this->accessToken,
             'plainTextToken' => $this->plainTextToken,
         ];
     }
@@ -50,7 +53,7 @@ class NewAccessToken implements Arrayable, Jsonable
     /**
      * Convert the object to its JSON representation.
      *
-     * @param  int  $options
+     * @param int $options
      * @return string
      */
     public function toJson($options = 0)

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -5,6 +5,15 @@ namespace Laravel\Sanctum;
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Sanctum\Contracts\HasAbilities;
 
+/**
+ * @property int    $id
+ * @property string $name
+ * @property string $token
+ * @property array  $abilities
+ * @property        $last_used_at
+ * @property        $expires_at
+ * @property        $created_at
+ */
 class PersonalAccessToken extends Model implements HasAbilities
 {
     /**
@@ -13,9 +22,9 @@ class PersonalAccessToken extends Model implements HasAbilities
      * @var array
      */
     protected $casts = [
-        'abilities' => 'json',
+        'abilities'    => 'json',
         'last_used_at' => 'datetime',
-        'expires_at' => 'datetime',
+        'expires_at'   => 'datetime',
     ];
 
     /**
@@ -52,7 +61,7 @@ class PersonalAccessToken extends Model implements HasAbilities
     /**
      * Find the token instance matching the given token.
      *
-     * @param  string  $token
+     * @param string $token
      * @return static|null
      */
     public static function findToken($token)
@@ -71,23 +80,23 @@ class PersonalAccessToken extends Model implements HasAbilities
     /**
      * Determine if the token has a given ability.
      *
-     * @param  string  $ability
+     * @param string $ability
      * @return bool
      */
     public function can($ability)
     {
         return in_array('*', $this->abilities) ||
-               array_key_exists($ability, array_flip($this->abilities));
+            array_key_exists($ability, array_flip($this->abilities));
     }
 
     /**
      * Determine if the token is missing a given ability.
      *
-     * @param  string  $ability
+     * @param string $ability
      * @return bool
      */
     public function cant($ability)
     {
-        return ! $this->can($ability);
+        return !$this->can($ability);
     }
 }


### PR DESCRIPTION
When I use phpstorm it can't find the accessToken. That's why these comments are needed.

**Before**
![Screenshot 2023-07-13 at 15 44 48](https://github.com/laravel/sanctum/assets/39323182/834c7240-ec8e-43af-8b0a-85811bcb3341)

**After**
![Screenshot 2023-07-13 at 15 44 19](https://github.com/laravel/sanctum/assets/39323182/31bae42d-f5b9-425c-9cfd-b171b214a57f)

![Screen Recording 2023-07-13 at 15 47 32](https://github.com/laravel/sanctum/assets/39323182/1bcc6ee3-8889-492b-bc6d-3a3fcd5a3550)





