### PR TITLE
Extract token generation into `generateToken` function

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -45,9 +45,11 @@ trait HasApiTokens
      */
     public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null)
     {
+        [$token, $plainTextToken] = $this->generateToken($name, $abilities, $expiresAt);
+
         $token = $this->tokens()->create([
             'name' => $name,
-            'token' => hash('sha256', $plainTextToken = Str::random(40)),
+            'token' => $token,
             'abilities' => $abilities,
             'expires_at' => $expiresAt,
         ]);
@@ -76,5 +78,20 @@ trait HasApiTokens
         $this->accessToken = $accessToken;
 
         return $this;
+    }
+
+    /**
+     * Generate a new personal access token.
+     *
+     * @param  string  $name
+     * @param  array  $abilities
+     * @param  \DateTimeInterface|null  $expiresAt
+     * @return \Laravel\Sanctum\NewAccessToken
+     */
+    protected function generateToken(string $name, array $abilities, ?DateTimeInterface $expiresAt)
+    {
+        $token = hash('sha256', $plainTextToken = Str::random(40));
+
+        return [$token, $plainTextToken];
     }
 }


### PR DESCRIPTION
This is a backward-compatible change that extracts the generation of personal access tokens into a separate function to allow for easier overriding. In most cases, overriding the `createToken` function is excessive because the only part of the creation process worth modifying is the token's generation.

The newly introduced `generateToken` function generates and returns the hashed and plain text token. This approach allows custom algorithms to be implemented without having to replace the entire `createToken` function every time you want to do this. My specific use-case for this change would be to generate PATs that are prefixed with the model type, e.g., `Str::snake(class_basename(static::class))`.

```php
<?php

class User extends Model implements HasApiTokensContract
{
    use HasApiTokens;

    protected function generateToken(string $name, array $abilities, ?\DateTimeInterface $expiresAt)
    {
        $token = hash('sha256', $plainTextToken = TypeId::fromPrefix('user'));

        return [$token, $plainTextToken];
    }
}
```