### PR TITLE
Ensure device has not been logged out

### DIFF
--- a/src/Http/Middleware/EnsureDeviceHasNotBeenLoggedOut.php
+++ b/src/Http/Middleware/EnsureDeviceHasNotBeenLoggedOut.php
@@ -21,11 +21,10 @@ class EnsureDeviceHasNotBeenLoggedOut
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (! $request->hasSession() || ! $request->user()) {
-            return $next($request);
-        }
-
-        if ($request->session()->get('password_hash_'.$this->auth->getDefaultDriver()) !== $request->user()->getAuthPassword()) {
+        if ($request->hasSession()
+            && $request->user()
+            && $request->session()->has($key = 'password_hash_'.$this->auth->getDefaultDriver())
+            && $request->session()->get($key) !== $request->user()->getAuthPassword()) {
             $this->logout($request);
 
             throw new AuthenticationException('Unauthenticated.', [$this->auth->getDefaultDriver()]);

--- a/src/Http/Middleware/EnsureDeviceHasNotBeenLoggedOut.php
+++ b/src/Http/Middleware/EnsureDeviceHasNotBeenLoggedOut.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Laravel\Sanctum\Http\Middleware;
+
+use Closure;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureDeviceHasNotBeenLoggedOut
+{
+    public function __construct(protected AuthFactory $auth)
+    {
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->hasSession() || ! $request->user()) {
+            return $next($request);
+        }
+
+        if ($request->session()->get('password_hash_'.$this->auth->getDefaultDriver()) !== $request->user()->getAuthPassword()) {
+            $this->logout($request);
+
+            throw new AuthenticationException('Unauthenticated.', [$this->auth->getDefaultDriver()]);
+        }
+
+        return $next($request);
+    }
+
+    protected function logout(Request $request)
+    {
+        $this->auth->logoutCurrentDevice();
+
+        $request->session()->flush();
+    }
+}

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -52,6 +52,7 @@ class EnsureFrontendRequestsAreStateful
             \Illuminate\Session\Middleware\StartSession::class,
             config('sanctum.middleware.validate_csrf_token'),
             config('sanctum.middleware.verify_csrf_token', \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class),
+            config('sanctum.middleware.ensure_not_logged_out', EnsureDeviceHasNotBeenLoggedOut::class),
         ])));
 
         array_unshift($middleware, function ($request, $next) {


### PR DESCRIPTION
This adds a middleware to check that the password hash in session is the same as the current users password, and logs the user out if not.

This fixes a security issue where an attacker can keep sending requests to an API using the sanctum auth after the password has been updated.

Scenario:
If a user is logged in in two different browsers, they change their password in one, the web session is invalidated in the other, but requests can still be sent via the sanctum cookie auth to the API.

refs #142 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
