### PR TITLE
Add deprecated annotation in `MissingScopeException`

### DIFF
--- a/src/Exceptions/MissingScopeException.php
+++ b/src/Exceptions/MissingScopeException.php
@@ -5,6 +5,10 @@ namespace Laravel\Sanctum\Exceptions;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Arr;
 
+/**
+ * @deprecated
+ * @see \Laravel\Sanctum\Exceptions\MissingAbilityException
+ */
 class MissingScopeException extends AuthorizationException
 {
     /**


### PR DESCRIPTION
This PR adds deprecated annotation in `MissingScopeException`