### PR TITLE
Use crc32b instead of crc32

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -49,7 +49,7 @@ trait HasApiTokens
             '%s%s%s',
             config('sanctum.token_prefix', ''),
             $tokenEntropy = Str::random(40),
-            hash('CRC32', $tokenEntropy)
+            hash('crc32b', $tokenEntropy)
         );
 
         $token = $this->tokens()->create([

--- a/tests/Feature/HasApiTokensTest.php
+++ b/tests/Feature/HasApiTokensTest.php
@@ -62,7 +62,7 @@ class HasApiTokensTest extends TestCase
         $tokenEntropy = substr(end($splitToken), 0, -8);
 
         $this->assertEquals(
-            hash('CRC32', $tokenEntropy),
+            hash('crc32b', $tokenEntropy),
             substr($token, -8)
         );
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## TLDR

php is interesting: this change makes it easier to validate the checksum in different langauges by using the IEEE CRC32 polynomial

## Reason for Change

So when implementing the validator for the checksum I noticed that PHP actually has a rich history with CRC32.

The `crc32()` method uses the IEEE polynomial that's become the defacto standard, but the `hash('crc32'…)` method uses a different polynomial that then becomes more difficult to validate in languages other than php. The `hash()` method calls the algorithm `crc32b` when you want to use the IEEE polynomial.

After working away on this issue in golang for awhile, I realized it would be better for the community to update it to the more universal polynomial.

After this change the one last thing to watchout for with this is that php reverses the crc32 byteorder compared to most other languages, but that can easily be overcome in the validator.