### PR TITLE
Skip EnsureFrontendRequestsAreStateful if request has valid token

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -4,6 +4,7 @@ namespace Laravel\Sanctum\Http\Middleware;
 
 use Illuminate\Routing\Pipeline;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 
 class EnsureFrontendRequestsAreStateful

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -17,6 +17,10 @@ class EnsureFrontendRequestsAreStateful
      */
     public function handle($request, $next)
     {
+        if ($request->bearerToken() && Auth::guard('sanctum')->user()) {
+            return $next($request);
+        }
+
         $this->configureSecureCookieSessions();
 
         return (new Pipeline(app()))->send($request)->through(


### PR DESCRIPTION
If [SPA Authentication](https://laravel.com/docs/10.x/sanctum#spa-authentication) is used, documentation suggests [enabling EnsureFrontendRequestsAreStateful middleware](https://laravel.com/docs/10.x/sanctum#sanctum-middleware) for api and populating first party endpoints in SANCTUM_STATEFUL_DOMAINS env variable.

This means token authentication from these domains does not work.

What if you want to use both [SPA Authentication](https://laravel.com/docs/10.x/sanctum#spa-authentication) and [API Token Authentication](https://laravel.com/docs/10.x/sanctum#api-token-authentication) from the same domain?

Consider following scenario:

- I want to use SPA Authentication but at the same time provide an interactive API documentation where users can try API endpoints with token
- javascript sends the request with token
- request fails because of invalid state

One possible solution is to host this documentation on another domain.

However I started thinking, is there a reason to check for csrf for API endpoints if _valid_ bearer token is provided?

I'm planning to override this middleware in my own application.

Rare scenario, but something to consider.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
