### PR TITLE
Accept null as a parameter for `Sanctum@getAccessTokenFromRequestUsing()`

### DIFF
--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -96,7 +96,7 @@ class Sanctum
      * @param  callable|null  $callback
      * @return void
      */
-    public static function getAccessTokenFromRequestUsing(callable|null $callback)
+    public static function getAccessTokenFromRequestUsing(?callable $callback)
     {
         static::$accessTokenRetrievalCallback = $callback;
     }

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -93,10 +93,10 @@ class Sanctum
     /**
      * Specify a callback that should be used to fetch the access token from the request.
      *
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @return void
      */
-    public static function getAccessTokenFromRequestUsing(callable $callback)
+    public static function getAccessTokenFromRequestUsing(callable|null $callback)
     {
         static::$accessTokenRetrievalCallback = $callback;
     }


### PR DESCRIPTION
Have a kind of an odd case where we're communicating between two applications and want to only allow for authorizing via Sanctum (on one endpoint) with a custom method of getting the access token. (The original app uses Passport, the new app uses Sanctum, so the HasApiTokens traits conflict on the User model).

```php
use App\Http\Controllers\Controller;
use Illuminate\Http\Request;
use Laravel\Sanctum\Sanctum;

class SwapTokenController extends Controller
{
    public function __invoke(SwapTokenRequest $request)
    {
        $originalCallback = Sanctum::$accessTokenRetrievalCallback ?? null;

        try {
            Sanctum::getAccessTokenFromRequestUsing(function (Request $request) {
                if (! $sanctumTokenString = $request->get('sanctum_token')) {
                    return null;
                }

                return $sanctumTokenString;
            });

            /** @var User|null $user */
            $sanctumGuard = app('auth')->guard('sanctum');
            $user = $sanctumGuard->user();

            // some other fun stuff here
        } finally {
            Sanctum::$accessTokenRetrievalCallback = $originalCallback;
        }
    }
}
```

`$originalCallback` is currently null for our app. It seems kind of weird that we can't just call `Sanctum::getAccessTokenFromRequestUsing($originalCallback)` instead of having to set the static property on the Sanctum object.