### PR TITLE
Laravel 11 Supports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,12 @@ jobs:
       fail-fast: true
       matrix:
         php: ['8.0', 8.1, 8.2, 8.3]
-        laravel: [9, 10]
+        laravel: [9, 10, 11]
         exclude:
+          - php: '8.0'
+            laravel: 11
+          - php: 8.1
+            laravel: 11
           - php: '8.0'
             laravel: 10
           - php: 8.3
@@ -45,4 +49,5 @@ jobs:
            composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,17 +16,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2, 8.3]
-        laravel: [9, 10, 11]
-        exclude:
-          - php: '8.0'
-            laravel: 11
-          - php: 8.1
-            laravel: 11
-          - php: '8.0'
-            laravel: 10
-          - php: 8.3
-            laravel: 9
+        php: [8.2, 8.3]
+        laravel: [11]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
 composer.lock
 /phpunit.xml
-.phpunit.result.cache
+/.phpunit.result.cache
+/.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
     "require-dev": {
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^7.28.2|^8.8.3|^9.0",
-        "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.6"
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "^8.2",
         "ext-json": "*",
-        "illuminate/console": "^9.21|^10.0|^11.0",
-        "illuminate/contracts": "^9.21|^10.0|^11.0",
-        "illuminate/database": "^9.21|^10.0|^11.0",
-        "illuminate/support": "^9.21|^10.0|^11.0"
+        "illuminate/console": "^11.0",
+        "illuminate/contracts": "^11.0",
+        "illuminate/database": "^11.0",
+        "illuminate/support": "^11.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^7.28.2|^8.8.3|^9.0",
+        "orchestra/testbench": "^9.0",
         "phpstan/phpstan": "^1.10"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,3 @@ parameters:
   ignoreErrors:
     - "#Unsafe usage of new static\\(\\)#"
     - "#\\(void\\) is used.#"
-    - "#Class App\\\\Http\\\\Middleware\\\\VerifyCsrfToken not found#"
-    - "#Class App\\\\Http\\\\Middleware\\\\EncryptCookies not found#"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertDeprecationsToExceptions="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
->
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
     <testsuites>
         <testsuite name="Sanctum Test Suite">
-            <directory suffix=".php">./tests/Unit</directory>
-            <directory suffix=".php">./tests/Controller</directory>
-            <directory suffix=".php">./tests/Feature</directory>
+            <directory suffix="Test.php">./tests/Unit</directory>
+            <directory suffix="Test.php">./tests/Controller</directory>
+            <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
https://github.com/laravel/sanctum/commit/0d4019d3ce52087f1f6e7952e97097ed59629e43 Changes made it incompatible with Laravel 10 and lower. 

It might be best to have Sanctum for Laravel 11 to drop support for older Laravel versions.
