### PR TITLE
Fix for issue #482

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -72,7 +72,7 @@ class EnsureFrontendRequestsAreStateful
      */
     public static function fromFrontend($request)
     {
-        $domain = $request->headers->get('referer') ?: $request->headers->get('origin');
+        $domain = $request->headers->get('referer') ?: $request->headers->get('origin') ?: $request->headers->get('host');
 
         if (is_null($domain)) {
             return false;


### PR DESCRIPTION
Ensures the domain is set correctly when determining if the given request is from the first-party application frontend.

https://github.com/laravel/sanctum/issues/482