### PR TITLE
feat: expiration by seconds

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -44,6 +44,8 @@ return [
     | considered expired. This will override any values set in the token's
     | "expires_at" attribute, but first-party sessions are not affected.
     |
+    | To set the number of seconds, use decimal.
+    |
     */
 
     'expiration' => null,

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -19,7 +19,7 @@ class Guard
     /**
      * The number of minutes tokens should be allowed to remain valid.
      *
-     * @var int
+     * @var int|float
      */
     protected $expiration;
 
@@ -156,7 +156,7 @@ class Guard
         }
 
         $isValid =
-            (! $this->expiration || $accessToken->created_at->gt(now()->subMinutes($this->expiration)))
+            (! $this->expiration || $accessToken->created_at->gt(now()->subSeconds($this->expiration * 60)))
             && (! $accessToken->expires_at || ! $accessToken->expires_at->isPast())
             && $this->hasValidProvider($accessToken->tokenable);
 

--- a/tests/Feature/GuardTest.php
+++ b/tests/Feature/GuardTest.php
@@ -42,8 +42,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-                ->with('web')
-                ->andReturn($webGuard);
+            ->with('web')
+            ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn($fakeUser = new User);
 
@@ -62,8 +62,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-                ->with('web')
-                ->andReturn($webGuard);
+            ->with('web')
+            ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -84,8 +84,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-                ->with('web')
-                ->andReturn($webGuard);
+            ->with('web')
+            ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -93,7 +93,8 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(), 'tokenable'
+            $user = UserFactory::new()->create(),
+            'tokenable'
         )->create([
             'name' => 'Test',
             'created_at' => now()->subMinutes(60),
@@ -122,7 +123,8 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(), 'tokenable'
+            $user = UserFactory::new()->create(),
+            'tokenable'
         )->create([
             'name' => 'Test',
             'expires_at' => now()->subMinutes(60),
@@ -151,10 +153,44 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         $token = PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(), 'tokenable'
+            $user = UserFactory::new()->create(),
+            'tokenable'
         )->create([
             'name' => 'Test',
             'expires_at' => now()->addMinutes(60),
+        ]);
+
+        $returnedUser = $guard->__invoke($request);
+
+        $this->assertEquals($user->id, $returnedUser->id);
+        $this->assertEquals($token->id, $returnedUser->currentAccessToken()->id);
+        $this->assertInstanceOf(DateTimeInterface::class, $returnedUser->currentAccessToken()->last_used_at);
+    }
+
+    public function test_authentication_with_token_succeeds_if_expires_at_not_passed_by_seconds()
+    {
+        $factory = Mockery::mock(AuthFactory::class);
+
+        $expiration = 1 / 60 * 10;
+        $guard = new Guard($factory, $expiration, 'users');
+
+        $webGuard = Mockery::mock(stdClass::class);
+
+        $factory->shouldReceive('guard')
+            ->with('web')
+            ->andReturn($webGuard);
+
+        $webGuard->shouldReceive('user')->once()->andReturn(null);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('Authorization', 'Bearer test');
+
+        $token = PersonalAccessTokenFactory::new()->for(
+            $user = UserFactory::new()->create(),
+            'tokenable'
+        )->create([
+            'name' => 'Test',
+            'expires_at' => now()->addSeconds(3),
         ]);
 
         $returnedUser = $guard->__invoke($request);
@@ -173,8 +209,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-                ->with('web')
-                ->andReturn($webGuard);
+            ->with('web')
+            ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -182,7 +218,8 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         $token = PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(), 'tokenable'
+            $user = UserFactory::new()->create(),
+            'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -209,7 +246,8 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            UserFactory::new(), 'tokenable'
+            UserFactory::new(),
+            'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -241,7 +279,8 @@ class GuardTest extends TestCase
         $request = Request::create('/', 'GET');
 
         PersonalAccessTokenFactory::new()->for(
-            UserFactory::new(), 'tokenable'
+            UserFactory::new(),
+            'tokenable'
         )->create([
             'name' => 'Test',
             'expires_at' => now()->subMinutes(60),
@@ -265,7 +304,8 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(), 'tokenable'
+            $user = UserFactory::new()->create(),
+            'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -286,7 +326,8 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(), 'tokenable'
+            $user = UserFactory::new()->create(),
+            'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -313,8 +354,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-                ->with('web')
-                ->andReturn($webGuard);
+            ->with('web')
+            ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -322,7 +363,8 @@ class GuardTest extends TestCase
         $request->headers->set('X-Auth-Token', 'test');
 
         $token = PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(), 'tokenable'
+            $user = UserFactory::new()->create(),
+            'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -349,8 +391,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-                ->with('web')
-                ->andReturn($webGuard);
+            ->with('web')
+            ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -358,7 +400,8 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            UserFactory::new(), 'tokenable'
+            UserFactory::new(),
+            'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -383,8 +426,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-                ->with('web')
-                ->andReturn($webGuard);
+            ->with('web')
+            ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -392,7 +435,8 @@ class GuardTest extends TestCase
         $request->headers->set('X-Auth-Token', 'test');
 
         PersonalAccessTokenFactory::new()->for(
-            UserFactory::new(), 'tokenable'
+            UserFactory::new(),
+            'tokenable'
         )->create([
             'name' => 'Test',
         ]);

--- a/tests/Feature/GuardTest.php
+++ b/tests/Feature/GuardTest.php
@@ -42,8 +42,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-            ->with('web')
-            ->andReturn($webGuard);
+                ->with('web')
+                ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn($fakeUser = new User);
 
@@ -62,8 +62,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-            ->with('web')
-            ->andReturn($webGuard);
+                ->with('web')
+                ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -84,8 +84,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-            ->with('web')
-            ->andReturn($webGuard);
+                ->with('web')
+                ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -93,8 +93,7 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(),
-            'tokenable'
+            $user = UserFactory::new()->create(), 'tokenable'
         )->create([
             'name' => 'Test',
             'created_at' => now()->subMinutes(60),
@@ -123,8 +122,7 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(),
-            'tokenable'
+            $user = UserFactory::new()->create(), 'tokenable'
         )->create([
             'name' => 'Test',
             'expires_at' => now()->subMinutes(60),
@@ -153,8 +151,7 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         $token = PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(),
-            'tokenable'
+            $user = UserFactory::new()->create(), 'tokenable'
         )->create([
             'name' => 'Test',
             'expires_at' => now()->addMinutes(60),
@@ -209,8 +206,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-            ->with('web')
-            ->andReturn($webGuard);
+                ->with('web')
+                ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -218,8 +215,7 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         $token = PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(),
-            'tokenable'
+            $user = UserFactory::new()->create(), 'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -246,8 +242,7 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            UserFactory::new(),
-            'tokenable'
+            UserFactory::new(), 'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -279,8 +274,7 @@ class GuardTest extends TestCase
         $request = Request::create('/', 'GET');
 
         PersonalAccessTokenFactory::new()->for(
-            UserFactory::new(),
-            'tokenable'
+            UserFactory::new(), 'tokenable'
         )->create([
             'name' => 'Test',
             'expires_at' => now()->subMinutes(60),
@@ -304,8 +298,7 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(),
-            'tokenable'
+            $user = UserFactory::new()->create(), 'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -326,8 +319,7 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(),
-            'tokenable'
+            $user = UserFactory::new()->create(), 'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -354,8 +346,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-            ->with('web')
-            ->andReturn($webGuard);
+                ->with('web')
+                ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -363,8 +355,7 @@ class GuardTest extends TestCase
         $request->headers->set('X-Auth-Token', 'test');
 
         $token = PersonalAccessTokenFactory::new()->for(
-            $user = UserFactory::new()->create(),
-            'tokenable'
+            $user = UserFactory::new()->create(), 'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -391,8 +382,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-            ->with('web')
-            ->andReturn($webGuard);
+                ->with('web')
+                ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -400,8 +391,7 @@ class GuardTest extends TestCase
         $request->headers->set('Authorization', 'Bearer test');
 
         PersonalAccessTokenFactory::new()->for(
-            UserFactory::new(),
-            'tokenable'
+            UserFactory::new(), 'tokenable'
         )->create([
             'name' => 'Test',
         ]);
@@ -426,8 +416,8 @@ class GuardTest extends TestCase
         $webGuard = Mockery::mock(stdClass::class);
 
         $factory->shouldReceive('guard')
-            ->with('web')
-            ->andReturn($webGuard);
+                ->with('web')
+                ->andReturn($webGuard);
 
         $webGuard->shouldReceive('user')->once()->andReturn(null);
 
@@ -435,8 +425,7 @@ class GuardTest extends TestCase
         $request->headers->set('X-Auth-Token', 'test');
 
         PersonalAccessTokenFactory::new()->for(
-            UserFactory::new(),
-            'tokenable'
+            UserFactory::new(), 'tokenable'
         )->create([
             'name' => 'Test',
         ]);


### PR DESCRIPTION
The only use case that I can think for this feature (other than for my interview code challenge) is:

- REST API app:
  - That means stateless.
  - Auth using bearer token only.
- And backend need to provide a broadcast endpoint for Websocket / EventSource (SSE):
  - Web API for Websocket / EventSource (SSE) cannot send custom headers.
  - As it is stateless, cookies & session is out of options.
  - The only option is token send as URL query.
- And token for Websocket / EventSource (SSE):
  - One time only.
  - **Short lived (< 10 seconds)**
 
