### PR TITLE
feat: expiration by seconds

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -44,6 +44,8 @@ return [
     | considered expired. This will override any values set in the token's
     | "expires_at" attribute, but first-party sessions are not affected.
     |
+    | To set the number of seconds, use decimal.
+    |
     */
 
     'expiration' => null,

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -19,7 +19,7 @@ class Guard
     /**
      * The number of minutes tokens should be allowed to remain valid.
      *
-     * @var int
+     * @var int|float
      */
     protected $expiration;
 
@@ -156,7 +156,7 @@ class Guard
         }
 
         $isValid =
-            (! $this->expiration || $accessToken->created_at->gt(now()->subMinutes($this->expiration)))
+            (! $this->expiration || $accessToken->created_at->gt(now()->subSeconds($this->expiration * 60)))
             && (! $accessToken->expires_at || ! $accessToken->expires_at->isPast())
             && $this->hasValidProvider($accessToken->tokenable);
 


### PR DESCRIPTION
The only use case that I can think for this feature (other than for my interview code challenge) is:

- REST API app:
  - That means stateless.
  - Auth using bearer token only.
- And backend need to provide a broadcast endpoint for Websocket / EventSource (SSE):
  - Web API for Websocket / EventSource (SSE) cannot send custom headers.
  - As it is stateless, cookies & session is out of options.
  - The only option is token send as URL query.
- And token for Websocket / EventSource (SSE):
  - One time only.
  - **Short lived (< 10 seconds)**