### PR TITLE
Updated `CsrfCookieController` to use named arguments

### DIFF
--- a/src/Http/Controllers/CsrfCookieController.php
+++ b/src/Http/Controllers/CsrfCookieController.php
@@ -17,9 +17,9 @@ class CsrfCookieController
     public function show(Request $request)
     {
         if ($request->expectsJson()) {
-            return new JsonResponse(null, 204);
+            return new JsonResponse(status: 204);
         }
 
-        return new Response('', 204);
+        return new Response(status: 204);
     }
 }


### PR DESCRIPTION
Used PHP 8 named arguments instead of passing default values for the first argument, to enhance readability.