### PR TITLE
Extract generate token method

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -36,21 +36,6 @@ trait HasApiTokens
     }
 
     /**
-     * Generate plain text token.
-     *
-     * @return string
-     */
-    public function generatePlainToken()
-    {
-        return sprintf(
-            '%s%s%s',
-            config('sanctum.token_prefix', ''),
-            $tokenEntropy = Str::random(40),
-            hash('crc32b', $tokenEntropy)
-        );
-    }
-
-    /**
      * Create a new personal access token for the user.
      *
      * @param  string  $name
@@ -60,7 +45,7 @@ trait HasApiTokens
      */
     public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null)
     {
-        $plainTextToken = $this->generatePlainToken();
+        $plainTextToken = $this->generateTokenString();
 
         $token = $this->tokens()->create([
             'name' => $name,
@@ -70,6 +55,21 @@ trait HasApiTokens
         ]);
 
         return new NewAccessToken($token, $token->getKey().'|'.$plainTextToken);
+    }
+
+    /**
+     * Generate the token string.
+     *
+     * @return string
+     */
+    public function generateTokenString()
+    {
+        return sprintf(
+            '%s%s%s',
+            config('sanctum.token_prefix', ''),
+            $tokenEntropy = Str::random(40),
+            hash('crc32b', $tokenEntropy)
+        );
     }
 
     /**

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -37,7 +37,7 @@ trait HasApiTokens
 
     /**
      * Generate plain text token.
-     * 
+     *
      * @return string
      */
     public function generatePlainToken()

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -36,6 +36,21 @@ trait HasApiTokens
     }
 
     /**
+     * Generate Plain Text Token
+     * 
+     * @return string
+     */
+    public function generatePlainToken()
+    {
+        return sprintf(
+            '%s%s%s',
+            config('sanctum.token_prefix', ''),
+            $tokenEntropy = Str::random(40),
+            hash('crc32b', $tokenEntropy)
+        );
+    }
+
+    /**
      * Create a new personal access token for the user.
      *
      * @param  string  $name
@@ -45,12 +60,7 @@ trait HasApiTokens
      */
     public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null)
     {
-        $plainTextToken = sprintf(
-            '%s%s%s',
-            config('sanctum.token_prefix', ''),
-            $tokenEntropy = Str::random(40),
-            hash('crc32b', $tokenEntropy)
-        );
+        $plainTextToken = $this->generatePlainToken();
 
         $token = $this->tokens()->create([
             'name' => $name,

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -36,7 +36,7 @@ trait HasApiTokens
     }
 
     /**
-     * Generate Plain Text Token
+     * Generate plain text token.
      * 
      * @return string
      */


### PR DESCRIPTION
I need to rewrite the `createToken` method, but the way the token is generated does not need to be modified by me. By extracting the method, I can avoid the impact of my rewrite on the original function.