### PR TITLE
Fix Sanctum token expiration to align with config expiration

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -3,6 +3,7 @@
 namespace Laravel\Sanctum;
 
 use DateTimeInterface;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 
 trait HasApiTokens
@@ -51,7 +52,7 @@ trait HasApiTokens
             'name' => $name,
             'token' => hash('sha256', $plainTextToken),
             'abilities' => $abilities,
-            'expires_at' => $expiresAt,
+            'expires_at' => $expiresAt ?? Date::now()->addMinutes(config('sanctum.expiration')),
         ]);
 
         return new NewAccessToken($token, $token->getKey().'|'.$plainTextToken);


### PR DESCRIPTION
This PR corrects the token expiration behavior in Laravel Sanctum to follow the 'expiration' setting in the sanctum config file, ensuring consistency with the [documented functionality](https://laravel.com/docs/10.x/sanctum#token-expiration).