### PR TITLE
Matching method to contract for createToken()

### DIFF
--- a/src/Contracts/HasApiTokens.php
+++ b/src/Contracts/HasApiTokens.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Sanctum\Contracts;
 
+use DateTimeInterface;
+
 interface HasApiTokens
 {
     /**
@@ -24,9 +26,10 @@ interface HasApiTokens
      *
      * @param  string  $name
      * @param  array  $abilities
+     * @param  \DateTimeInterface|null  $expiresAt
      * @return \Laravel\Sanctum\NewAccessToken
      */
-    public function createToken(string $name, array $abilities = ['*']);
+    public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null);
 
     /**
      * Get the access token currently associated with the user.


### PR DESCRIPTION
## Errors

The contract does not include the third parameter `DateTimeInterface $expiresAt`.

Contract:
```php
public function createToken(string $name, array $abilities = ['*']);
```
Trait:
```php
public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null)
```

From PHPStan:
```
Error: Method Laravel\Sanctum\Contracts\HasApiTokens::createToken() invoked with 3 parameters, 1-2 required.
```

***Should this pull request be made against 3.x instead?***

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
