### PR TITLE
fix user not being able to logout

### DIFF
--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -64,8 +64,9 @@ class AuthenticateSession
         }
 
         return tap($next($request), function () use ($request, $guards) {
-            if (! is_null($request->user())) {
-                $this->storePasswordHashInSession($request, $guards->keys()->first());
+            $guard = $guards->keys()->first();
+            if (auth($guard)->hasUser()) {
+                $this->storePasswordHashInSession($request, $guard);
             }
         });
     }
@@ -79,7 +80,7 @@ class AuthenticateSession
      */
     protected function storePasswordHashInSession($request, string $guard)
     {
-        if (! $request->user()) {
+        if (! auth($guard)->hasUser()) {
             return;
         }
 

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -85,7 +85,7 @@ class AuthenticateSession
         }
 
         $request->session()->put([
-            "password_hash_{$guard}" => $request->user()->getAuthPassword(),
+            "password_hash_{$guard}" => auth($guard)->user()->getAuthPassword(),
         ]);
     }
 }


### PR DESCRIPTION
issue description: when user logins as user A  and then logs out and tries to login as user B they can not send request to route protected by auth:sanctum middleware

how to reproduce: i prepared two repositories ([back](https://github.com/GigaGiorgadze/sanctum-logout-bug-back), [front](https://github.com/GigaGiorgadze/sanctum-logout-bug-front)) for reproducing, all you have to do is install backend and frontend repositories, following install guideline in the readme and then press buttons on frontend in following order: login gmail. fetch me, logout, login redberry, fetch me. this second "fetch me" should return 401 without this fix applied. instead of going  and changing vendor i crated custom middleware which implements same fix so you can just replace  'authenticate_session' in config/sanctum.php with this `'authenticate_session' => App\Http\Middleware\AuthenticateSanctumRequest::class,` and issue will be fixed

video proof without fix: 

https://github.com/laravel/sanctum/assets/75663118/54282905-585d-4af7-8f16-e3e3cf895b26

video proof with fix: 

https://github.com/laravel/sanctum/assets/75663118/82672379-dd1a-4abb-96fb-67a33e1da876

i believe  this issue was caused because user was grabbed from the request even though user was logged out during that request. using auth guard to grab it from current session seemed to fix it

