### PR TITLE
Add regenerateToken method to HasApiTokens

### DIFF
--- a/src/Contracts/HasApiTokens.php
+++ b/src/Contracts/HasApiTokens.php
@@ -32,6 +32,16 @@ interface HasApiTokens
     public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null);
 
     /**
+     * Regenerate new personal access token for the user.
+     *
+     * @param  string  $name
+     * @param  array  $abilities
+     * @param  \DateTimeInterface|null  $expiresAt
+     * @return \Laravel\Sanctum\NewAccessToken
+     */
+    public function regenerateToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null);
+
+    /**
      * Get the access token currently associated with the user.
      *
      * @return \Laravel\Sanctum\Contracts\HasAbilities

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -58,6 +58,21 @@ trait HasApiTokens
     }
 
     /**
+     * Regenerate new personal access token for the user.
+     *
+     * @param  string  $name
+     * @param  array  $abilities
+     * @param  \DateTimeInterface|null  $expiresAt
+     * @return \Laravel\Sanctum\NewAccessToken
+     */
+    public function regenerateToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null)
+    {
+        $this->tokens()->delete();
+
+        return $this->createToken($name, $abilities, $expiresAt);
+    }
+
+    /**
      * Generate the token string.
      *
      * @return string

--- a/tests/Feature/HasApiTokensTest.php
+++ b/tests/Feature/HasApiTokensTest.php
@@ -39,6 +39,31 @@ class HasApiTokensTest extends TestCase
         );
     }
 
+    public function test_tokens_can_be_regenerated()
+    {
+        $class = new ClassThatHasApiTokens;
+        $time = Carbon::now();
+
+        $regeneratedToken = $class->regenerateToken('test', ['foo'], $time);
+
+        [$id, $token] = explode('|', $regeneratedToken->plainTextToken);
+
+        $this->assertEquals(
+            $regeneratedToken->accessToken->token,
+            hash('sha256', $token)
+        );
+
+        $this->assertEquals(
+            $regeneratedToken->accessToken->id,
+            $id
+        );
+
+        $this->assertEquals(
+            $time->toDateTimeString(),
+            $regeneratedToken->accessToken->expires_at->toDateTimeString()
+        );
+    }
+
     public function test_can_check_token_abilities()
     {
         $class = new ClassThatHasApiTokens;
@@ -79,6 +104,11 @@ class ClassThatHasApiTokens implements HasApiTokensContract
             public function create(array $attributes)
             {
                 return new PersonalAccessToken($attributes);
+            }
+
+            public function delete()
+            {
+                return 1;
             }
         };
     }


### PR DESCRIPTION
This PR introduces new `regenerateToken` method to the `HasApiTokens` traits in **Laravel Sanctum**. This method allows users to regenerate a new personal access token while revoking the existing one.

### Changes:

- Added `regenerateToken` method to the `HasApiTokens` traits and contract.
- Implemented functionality to delete existing tokens and generate a new one with specified attributes.

### Use-Case

For scenarios requiring frequent rotation of access tokens to mitigate security risks, the addition of a `regenerateToken` method to Laravel Sanctum can greatly simplify token management without manually creating it into our own model.

### Testing:

A unit test have been added to ensure the proper functionality of the `regenerateToken` method.