### PR TITLE
Fix/unable to logout

### DIFF
--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -64,11 +64,23 @@ class AuthenticateSession
         }
 
         return tap($next($request), function () use ($request, $guards) {
-            $guard = $this->getUsersGuard($guards->keys());
+            $guard = $this->getFirstGuardWithUser($guards->keys());
+
             if (! is_null($guard)) {
                 $this->storePasswordHashInSession($request, $guard);
             }
         });
+    }
+
+    /**
+     * Get the first authentication guard that has a user.
+     *
+     * @param  \Illuminate\Support\Collection  $guards
+     * @return string|null
+     */
+    protected function getFirstGuardWithUser(Collection $guards)
+    {
+        return $guards->first(fn ($guard) => $this->auth->guard($guard)->hasUser());
     }
 
     /**
@@ -87,10 +99,5 @@ class AuthenticateSession
         $request->session()->put([
             "password_hash_{$guard}" => $this->auth->guard($guard)->user()->getAuthPassword(),
         ]);
-    }
-
-    protected function getUsersGuard(Collection $guards): string|null
-    {
-        return $guards->first(fn ($guard) => $this->auth->guard($guard)->hasUser());
     }
 }

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -64,8 +64,9 @@ class AuthenticateSession
         }
 
         return tap($next($request), function () use ($request, $guards) {
-            if (! is_null($request->user())) {
-                $this->storePasswordHashInSession($request, $guards->keys()->first());
+            $guard = $guards->keys()->first();
+            if (auth($guard)->hasUser()) {
+                $this->storePasswordHashInSession($request, $guard);
             }
         });
     }
@@ -79,7 +80,7 @@ class AuthenticateSession
      */
     protected function storePasswordHashInSession($request, string $guard)
     {
-        if (! $request->user()) {
+        if (! auth($guard)->hasUser()) {
             return;
         }
 

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -85,7 +85,7 @@ class AuthenticateSession
         }
 
         $request->session()->put([
-            "password_hash_{$guard}" => $request->user()->getAuthPassword(),
+            "password_hash_{$guard}" => auth($guard)->user()->getAuthPassword(),
         ]);
     }
 }

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -64,9 +64,7 @@ class AuthenticateSession
         }
 
         return tap($next($request), function () use ($request, $guards) {
-            $guard = $this->getFirstGuardWithUser($guards->keys());
-
-            if (! is_null($guard)) {
+            if (! is_null($guard = $this->getFirstGuardWithUser($guards->keys()))) {
                 $this->storePasswordHashInSession($request, $guard);
             }
         });
@@ -92,10 +90,6 @@ class AuthenticateSession
      */
     protected function storePasswordHashInSession($request, string $guard)
     {
-        if (! $this->auth->guard($guard)->hasUser()) {
-            return;
-        }
-
         $request->session()->put([
             "password_hash_{$guard}" => $this->auth->guard($guard)->user()->getAuthPassword(),
         ]);

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -80,7 +80,6 @@ class AuthenticateSession
      */
     protected function storePasswordHashInSession($request, string $guard)
     {
-
         if (! $this->auth->guard($guard)->hasUser()) {
             return;
         }

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -78,7 +78,12 @@ class AuthenticateSession
      */
     protected function getFirstGuardWithUser(Collection $guards)
     {
-        return $guards->first(fn ($guard) => $this->auth->guard($guard)->hasUser());
+        return $guards->first(function ($guard) {
+            $guardInstance = $this->auth->guard($guard);
+
+            return method_exists($guardInstance, 'hasUser') &&
+                   $guardInstance->hasUser();
+        });
     }
 
     /**

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -65,6 +65,7 @@ class AuthenticateSession
 
         return tap($next($request), function () use ($request, $guards) {
             $guard = $guards->keys()->first();
+
             if ($this->auth->guard($guard)->hasUser()) {
                 $this->storePasswordHashInSession($request, $guard);
             }

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -64,9 +64,8 @@ class AuthenticateSession
         }
 
         return tap($next($request), function () use ($request, $guards) {
-            $guard = $guards->keys()->first();
-
-            if ($this->auth->guard($guard)->hasUser()) {
+            $guard = $this->getUsersGuard($guards->keys());
+            if (! is_null($guard)) {
                 $this->storePasswordHashInSession($request, $guard);
             }
         });
@@ -81,6 +80,7 @@ class AuthenticateSession
      */
     protected function storePasswordHashInSession($request, string $guard)
     {
+
         if (! $this->auth->guard($guard)->hasUser()) {
             return;
         }
@@ -88,5 +88,10 @@ class AuthenticateSession
         $request->session()->put([
             "password_hash_{$guard}" => $this->auth->guard($guard)->user()->getAuthPassword(),
         ]);
+    }
+
+    protected function getUsersGuard(Collection $guards): string|null
+    {
+        return $guards->first(fn ($guard) => $this->auth->guard($guard)->hasUser());
     }
 }

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -65,7 +65,7 @@ class AuthenticateSession
 
         return tap($next($request), function () use ($request, $guards) {
             $guard = $guards->keys()->first();
-            if (auth($guard)->hasUser()) {
+            if ($this->auth->guard($guard)->hasUser()) {
                 $this->storePasswordHashInSession($request, $guard);
             }
         });
@@ -80,12 +80,12 @@ class AuthenticateSession
      */
     protected function storePasswordHashInSession($request, string $guard)
     {
-        if (! auth($guard)->hasUser()) {
+        if (! $this->auth->guard($guard)->hasUser()) {
             return;
         }
 
         $request->session()->put([
-            "password_hash_{$guard}" => auth($guard)->user()->getAuthPassword(),
+            "password_hash_{$guard}" => $this->auth->guard($guard)->user()->getAuthPassword(),
         ]);
     }
 }


### PR DESCRIPTION
this is follow up to previous [pull request](https://github.com/laravel/sanctum/pull/508)

# Issue description
`AuthenticateSession` middleware sets password hash in session after request is sent but uses user from request, this results password hash not being removed from the session after loggout.
this does not cause user to be counted as authenticated but in case user tries to log in with different user following request will return 401 because passwords do not match.

# how to replicate
i created two repositories for this, to replicate all u have to do is configure them locally according to readme. [back](https://github.com/GigaGiorgadze/sanctum-logout-bug-back) and [front](https://github.com/GigaGiorgadze/sanctum-logout-bug-front). after installing this you you should go in frontend and click buttons in following order: "login gmail", "fetch me", "logout", "login redberry", "fetch me". this last request from frontend will fail without this fix.  here is video:   

https://github.com/laravel/sanctum/assets/75663118/701122eb-60fe-4241-9f34-651914ed29a3


# why it does not break any existing features
all previous tests are passing and all i changed was place of getting user, meaning i changed getting user from request to getting them from auth() guard which is up to date after log out.

# tests
i added one test case in FrontendRequestsAreStatefulTest which verifies that password_hash_web is removed if user was logged out during that request and is set if user was not logged out during that request.

without fix implemented this line fails: 

```php
$this->getJson('/sanctum/api/logout', [
            'origin' => config('app.url'),
        ])->assertOk()->assertSee('logged out')->assertSessionMissing('password_hash_web');
```