### PR TITLE
Check if $tokenable is valid by checking whether it implements HasApiTokens contract

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -5,6 +5,7 @@ namespace Laravel\Sanctum;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use Laravel\Sanctum\Contracts\HasApiTokens;
 use Laravel\Sanctum\Events\TokenAuthenticated;
 
 class Guard
@@ -100,9 +101,7 @@ class Guard
      */
     protected function supportsTokens($tokenable = null)
     {
-        return $tokenable && in_array(HasApiTokens::class, class_uses_recursive(
-            get_class($tokenable)
-        ));
+        return $tokenable && $tokenable instanceof HasApiTokens;
     }
 
     /**


### PR DESCRIPTION
Check if $tokenable is valid by checking whether it implements HasApiTokens contract instead of checking the specific (trait) implementation.

This relates to https://github.com/laravel/sanctum/issues/506. 

If this is acceptable, with or without more changes, it would also require an update to the docs page. This is because you would have to explicitly implement the `HasApiTokens`-interface and not just use the `HasApiTokens`-trait.