### PR TITLE
Adding data column to personalAccessToken Table

### DIFF
--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('name');
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();
+            $table->text('data')->nullable();
             $table->timestamp('last_used_at')->nullable();
             $table->timestamp('expires_at')->nullable();
             $table->timestamps();

--- a/src/Contracts/HasApiTokens.php
+++ b/src/Contracts/HasApiTokens.php
@@ -29,7 +29,7 @@ interface HasApiTokens
      * @param  \DateTimeInterface|null  $expiresAt
      * @return \Laravel\Sanctum\NewAccessToken
      */
-    public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null);
+    public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null, $data = []);
 
     /**
      * Get the access token currently associated with the user.

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -43,7 +43,7 @@ trait HasApiTokens
      * @param  \DateTimeInterface|null  $expiresAt
      * @return \Laravel\Sanctum\NewAccessToken
      */
-    public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null)
+    public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null, $data = [])
     {
         $plainTextToken = $this->generateTokenString();
 
@@ -52,9 +52,10 @@ trait HasApiTokens
             'token' => hash('sha256', $plainTextToken),
             'abilities' => $abilities,
             'expires_at' => $expiresAt,
+            'data' => $data
         ]);
 
-        return new NewAccessToken($token, $token->getKey().'|'.$plainTextToken);
+        return new NewAccessToken($token, $token->getKey() . '|' . $plainTextToken);
     }
 
     /**

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -52,10 +52,10 @@ trait HasApiTokens
             'token' => hash('sha256', $plainTextToken),
             'abilities' => $abilities,
             'expires_at' => $expiresAt,
-            'data' => $data
+            'data' => $data,
         ]);
 
-        return new NewAccessToken($token, $token->getKey() . '|' . $plainTextToken);
+        return new NewAccessToken($token, $token->getKey().'|'.$plainTextToken);
     }
 
     /**

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -16,7 +16,7 @@ class PersonalAccessToken extends Model implements HasAbilities
         'abilities' => 'json',
         'last_used_at' => 'datetime',
         'expires_at' => 'datetime',
-        'data' => 'json'
+        'data' => 'json',
     ];
 
     /**
@@ -90,6 +90,6 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public function cant($ability)
     {
-        return !$this->can($ability);
+        return ! $this->can($ability);
     }
 }

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -16,6 +16,7 @@ class PersonalAccessToken extends Model implements HasAbilities
         'abilities' => 'json',
         'last_used_at' => 'datetime',
         'expires_at' => 'datetime',
+        'data' => 'json'
     ];
 
     /**
@@ -26,6 +27,7 @@ class PersonalAccessToken extends Model implements HasAbilities
     protected $fillable = [
         'name',
         'token',
+        'data',
         'abilities',
         'expires_at',
     ];
@@ -77,7 +79,7 @@ class PersonalAccessToken extends Model implements HasAbilities
     public function can($ability)
     {
         return in_array('*', $this->abilities) ||
-               array_key_exists($ability, array_flip($this->abilities));
+            array_key_exists($ability, array_flip($this->abilities));
     }
 
     /**
@@ -88,6 +90,6 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public function cant($ability)
     {
-        return ! $this->can($ability);
+        return !$this->can($ability);
     }
 }

--- a/tests/Feature/HasApiTokensTest.php
+++ b/tests/Feature/HasApiTokensTest.php
@@ -50,7 +50,7 @@ class HasApiTokensTest extends TestCase
 
     public function test_token_checksum_is_valid()
     {
-        $config = require __DIR__ . '/../../config/sanctum.php';
+        $config = require __DIR__ .'/../../config/sanctum.php';
         $this->app['config']->set('sanctum.token_prefix', $config['token_prefix']);
 
         $class = new ClassThatHasApiTokens;

--- a/tests/Feature/HasApiTokensTest.php
+++ b/tests/Feature/HasApiTokensTest.php
@@ -19,7 +19,7 @@ class HasApiTokensTest extends TestCase
         $class = new ClassThatHasApiTokens;
         $time = Carbon::now();
 
-        $newToken = $class->createToken('test', ['foo'], $time);
+        $newToken = $class->createToken('test', ['foo'], $time, ['test' => 'test']);
 
         [$id, $token] = explode('|', $newToken->plainTextToken);
 
@@ -50,7 +50,7 @@ class HasApiTokensTest extends TestCase
 
     public function test_token_checksum_is_valid()
     {
-        $config = require __DIR__.'/../../config/sanctum.php';
+        $config = require __DIR__ . '/../../config/sanctum.php';
         $this->app['config']->set('sanctum.token_prefix', $config['token_prefix']);
 
         $class = new ClassThatHasApiTokens;

--- a/workbench/database/factories/PersonalAccessTokenFactory.php
+++ b/workbench/database/factories/PersonalAccessTokenFactory.php
@@ -32,7 +32,7 @@ class PersonalAccessTokenFactory extends Factory
             'token' => hash('sha256', 'test'),
             'created_at' => Carbon::now(),
             'expires_at' => null,
-            'data' => ['test' => 'test']
+            'data' => ['test' => 'test'],
         ];
     }
 }

--- a/workbench/database/factories/PersonalAccessTokenFactory.php
+++ b/workbench/database/factories/PersonalAccessTokenFactory.php
@@ -32,6 +32,7 @@ class PersonalAccessTokenFactory extends Factory
             'token' => hash('sha256', 'test'),
             'created_at' => Carbon::now(),
             'expires_at' => null,
+            'data' => ['test' => 'test']
         ];
     }
 }


### PR DESCRIPTION
This pull request introduces a new data column to the personal_access_tokens table in Laravel Sanctum. The data column is intended to store additional JSON-encoded information related to personal access tokens.
Changes

    Migration: Added data column in 2019_12_14_000001_create_personal_access_tokens_table.php.
    Model: Updated PersonalAccessToken.php to include data in $fillable and cast it to JSON.
    Token Creation: Modified HasApiTokens.php and Contracts/HasApiTokens.php to accept data in createToken method.
    Testing: Updated HasApiTokensTest.php to include tests for data attribute.
    Factory: Added data attribute in PersonalAccessTokenFactory.php.

Impact

This change allows developers to store additional metadata with personal access tokens, enhancing the flexibility and functionality of token management in Laravel Sanctum.
