### PR TITLE
feat: add config option to configure remaining middlware

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -77,8 +77,8 @@ return [
     'middleware' => [
         'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
         'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
-        'add_queued_cookies_to_response'=> \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-        'start_session'=> Illuminate\Session\Middleware\StartSession::class,
+        'add_queued_cookies_to_response' => Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+        'start_session' => Illuminate\Session\Middleware\StartSession::class,
         'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
     ],
 

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -77,6 +77,8 @@ return [
     'middleware' => [
         'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
         'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
+        'add_queued_cookies_to_response'=> \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+        'start_session'=> Illuminate\Session\Middleware\StartSession::class,
         'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
     ],
 

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -48,8 +48,8 @@ class EnsureFrontendRequestsAreStateful
     {
         $middleware = array_values(array_filter(array_unique([
             config('sanctum.middleware.encrypt_cookies', \Illuminate\Cookie\Middleware\EncryptCookies::class),
-            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
+            config('sanctum.middleware.add_queued_cookies_to_response', \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class),
+            config('sanctum.middleware.start_session', \Illuminate\Session\Middleware\StartSession::class),
             config('sanctum.middleware.validate_csrf_token', config('sanctum.middleware.verify_csrf_token', \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class)),
             config('sanctum.middleware.authenticate_session'),
         ])));


### PR DESCRIPTION
Thank you for the excellent package.

This pull request introduces a feature to customize middleware configuration for Illuminate\Session\Middleware\StartSession::class and Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class.

I understand that while this middleware can be configured using [Laravel's documentation](https://laravel.com/docs/11.x/middleware#laravels-default-middleware-groups), it appears to be only possible for the web group and not for the api group, as these middleware directly applies from `EnsureFrontendRequestsAreStateful`, 