### PR TITLE
Fix: Cast Model Key to Integer for PostgreSQL Performance Improvement

### DIFF
--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -63,6 +63,10 @@ class PersonalAccessToken extends Model implements HasAbilities
 
         [$id, $token] = explode('|', $token, 2);
 
+        if ((new static())->getKeyType() === 'int') {
+            $id = (int) $id;
+        }
+
         if ($instance = static::find($id)) {
             return hash_equals($instance->token, hash('sha256', $token)) ? $instance : null;
         }


### PR DESCRIPTION
Added a check to cast the model key to an integer if the key type is 'int'. This ensures that PostgreSQL uses an index scan instead of a sequential scan, thereby improving query performance.

- Check if the model key type is 'int'.
- Cast the key to an integer if it is 'int'.
- Improves performance by ensuring PostgreSQL uses index scan instead of seq scan.

### Summary

This pull request addresses a performance issue in PostgreSQL when querying by primary key. When the primary key is not cast to an integer, PostgreSQL performs a sequential scan instead of an index scan, leading to suboptimal performance.

### Changes

- Added a check in the `findToken` method to determine if the model key type is 'int'.
- If the key type is 'int', the key is cast to an integer before the query is executed.
- This change ensures that PostgreSQL uses an index scan, improving query performance.

### Details

In the `findToken` method, I added the following lines:

```php
if ((new static())->getKeyType() == 'int') {
    $id = (int) $id;
}
```

### PostgreSQL
- Version 14.12
- Query
```sql
EXPLAIN ANALYSE SELECT * FROM personal_access_tokens WHERE personal_access_tokens.id = '12' LIMIT 1;
```
- Output
<img width="986" alt="image" src="https://github.com/user-attachments/assets/49bf3e42-ed97-41f3-ac15-f4e077b44832">


### Why
In PostgreSQL, when querying with a primary key that is not cast to the appropriate type, the query planner may opt for a sequential scan instead of utilizing the primary key index. By explicitly casting the primary key to an integer, we can ensure that PostgreSQL uses an index scan, which is significantly faster for primary key lookups.

### Testing
This change has been tested locally to verify that:

The query performance is improved with the cast.
1. There are no regressions or unexpected behaviors introduced by this change.
Impact
2. This fix should primarily benefit applications using PostgreSQL with large datasets, where the performance difference between a sequential scan and an index scan can be substantial.

### Related Issues
None.