### PR TITLE
Session cookie setting overhaul

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -35,7 +35,6 @@ class EnsureFrontendRequestsAreStateful
     {
         config([
             'session.http_only' => true,
-            'session.same_site' => 'lax',
         ]);
     }
 


### PR DESCRIPTION
I suggest transferring the ability to manage cookie settings to developers, this may be useful in a situation of developing the backend on the server and the interface locally. I also think that other developers will be able to find more uses.