### PR TITLE
Session cookie setting overhaul

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -65,6 +65,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Session Settings
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the session settings used by Sanctum for secure
+    | cookie management. You may adjust the HTTP Only and Same Site policies
+    | as required to suit your application's needs.
+    |
+    */
+
+    'session' => [
+        'http_only' => env('SANCTUM_SESSION_HTTP_ONLY', true),
+        'same_site' => env('SANCTUM_SESSION_SAME_SITE', 'lax'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Sanctum Middleware
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -34,8 +34,8 @@ class EnsureFrontendRequestsAreStateful
     protected function configureSecureCookieSessions()
     {
         config([
-            'session.http_only' => true,
-            'session.same_site' => 'lax',
+            'session.http_only' => config('sanctum.session.http_only', true),
+            'session.same_site' => config('sanctum.session.same_site', 'lax'),
         ]);
     }
 


### PR DESCRIPTION
We have a problem.

Change in same_site and http_only settings in session.php leads to different responses to authorization requests and requests to the authorized zone. This results in authorization and cookie installation errors in the browser. 

I've added additional settings to the sanctum module for more accurate cookie file configuration. Backward compatibility is preserved.