### PR TITLE
[4.x] Remove `AuthenticateSession::handle` return type

### DIFF
--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Symfony\Component\HttpFoundation\Response;
 
 class AuthenticateSession
 {

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -33,12 +33,13 @@ class AuthenticateSession
     /**
      * Handle an incoming request.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      * @return \Illuminate\Http\Response
      *
      * @throws \Illuminate\Auth\AuthenticationException
      */
-    public function handle(Request $request, Closure $next)
+    public function handle($request, $next)
     {
         if (! $request->hasSession() || ! $request->user()) {
             return $next($request);
@@ -93,7 +94,7 @@ class AuthenticateSession
      * @param  string  $guard
      * @return void
      */
-    protected function storePasswordHashInSession($request, string $guard)
+    protected function storePasswordHashInSession($request, $guard)
     {
         $request->session()->put([
             "password_hash_{$guard}" => $this->auth->guard($guard)->user()->getAuthPassword(),

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Sanctum\Http\Middleware;
 
-use Closure;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -35,10 +35,11 @@ class AuthenticateSession
      * Handle an incoming request.
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @return \Illuminate\Http\Response
      *
      * @throws \Illuminate\Auth\AuthenticationException
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle(Request $request, Closure $next)
     {
         if (! $request->hasSession() || ! $request->user()) {
             return $next($request);


### PR DESCRIPTION
This PR removes the enforced return type on the `AuthenticateSession::handle` method. This may have accidentally slipped in from a PR or something.