### PR TITLE
Chaperone tokenable model

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -21,7 +21,7 @@ trait HasApiTokens
      */
     public function tokens()
     {
-        return $this->morphMany(Sanctum::$personalAccessTokenModel, 'tokenable');
+        return $this->morphMany(Sanctum::$personalAccessTokenModel, 'tokenable')->chaperone();
     }
 
     /**


### PR DESCRIPTION
Since this repository requires laravel v11 lets automatically chaperone the tokenable relationship since its somewhat convoluted to eager load. 

For example:
```php
// Will cause a lazy loading exception if Model::preventLazyLoading() is enabled
$user->tokens->map(fn (PersonalAccessToken $token) {
    dump($token->tokenable);
});
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
