### PR TITLE
respectively custom session guard

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -17,6 +17,13 @@ class Guard
     protected $auth;
 
     /**
+     * guards will be checked.
+     *
+     * @var string|string[]|null
+     */
+    protected $guards;
+
+    /**
      * The number of minutes tokens should be allowed to remain valid.
      *
      * @var int
@@ -36,13 +43,15 @@ class Guard
      * @param  \Illuminate\Contracts\Auth\Factory  $auth
      * @param  int  $expiration
      * @param  string  $provider
+     * @param  string|string[]|null  $guards
      * @return void
      */
-    public function __construct(AuthFactory $auth, $expiration = null, $provider = null)
+    public function __construct(AuthFactory $auth, $expiration = null, $provider = null, $guards = null)
     {
         $this->auth = $auth;
         $this->expiration = $expiration;
         $this->provider = $provider;
+        $this->guards = $guards;
     }
 
     /**
@@ -53,7 +62,7 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        foreach (Arr::wrap(config('sanctum.guard', 'web')) as $guard) {
+        foreach (Arr::wrap($this->guards ?? config('sanctum.guard', 'web')) as $guard) {
             if ($user = $this->auth->guard($guard)->user()) {
                 return $this->supportsTokens($user)
                     ? $user->withAccessToken(new TransientToken)

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -103,7 +103,7 @@ class SanctumServiceProvider extends ServiceProvider
     protected function createGuard($auth, $config)
     {
         return new RequestGuard(
-            new Guard($auth, config('sanctum.expiration'), $config['provider']),
+            new Guard($auth, config('sanctum.expiration'), $config['provider'], $config['with_guard'] ?? null),
             request(),
             $auth->createUserProvider($config['provider'] ?? null)
         );


### PR DESCRIPTION
When multiple guard users use the sanctum driver, there is a problem that session users are confused.

Example:

config/auth.php

```php
'guards' => [
        'web' => [
            'driver' => 'session',
            'provider' => 'users',
        ],
        'api' => [
            'driver' => 'sanctum',
            'provider' => 'users',
        ],
        'admin' => [
            'driver' => 'session',
            'provider' => 'admins',
        ],
        'admin-api' => [
            'driver' => 'sanctum',
            'provider' => 'admins',
        ],
    ],
```

config/sanctum.php

```php
'guard' => [
        'web',
        'admin',
    ],
```

Now login admin guard user, and print all guard user

routes/api.php

```php
Route::get('user', function () {
    $webUser = auth('web')->user();
    $webApiUser = auth('api')->user();
    $adminUser = auth('admin')->user();
    $adminApiUser = auth('admin-api')->user();
    dd(
        'web: ' . ($webUser ? $webUser::class . "[{$webUser['id']}]" : null),
        'api: ' . ($webApiUser ? $webApiUser::class . "[{$webApiUser['id']}]" : null),
        'admin: ' . ($adminUser ? $adminUser::class . "[{$adminUser['id']}]" : null),
        'admin-api: ' . ($adminApiUser ? $adminApiUser::class . "[{$adminApiUser['id']}]" : null),
    );
});
```

result: api guard return admin user

```
"web: " // routes\api.php:10
"api: App\Models\Admin[1]" // routes\api.php:10
"admin: App\Models\Admin[1]" // routes\api.php:10
"admin-api: App\Models\Admin[1]" // routes\api.php:10
```

For this we need to check the type of user or add middleware to fix the problem, but this is not a good idea.

New auth config like:

```php
'guards' => [
        'web' => [
            'driver' => 'session',
            'provider' => 'users',
        ],
        'api' => [
            'driver' => 'sanctum',
            'with_guard' => 'web',
            'provider' => 'users',
        ],
        'admin' => [
            'driver' => 'session',
            'provider' => 'admins',
        ],
        'admin-api' => [
            'driver' => 'sanctum',
            'with_guard' => ['admin'],
            'provider' => 'admins',
        ],
    ],
```

sanctum driver need to know which guard can be scanned, private, not global.

If there no with_guard field or with_guard is null, driver will use old rules.


