### PR TITLE
[4.x] use method instead of array for casts on `PersonalAccessToken`

### DIFF
--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -10,18 +10,21 @@ class PersonalAccessToken extends Model implements HasAbilities
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @return array<string, string>
      */
-    protected $casts = [
-        'abilities' => 'json',
-        'last_used_at' => 'datetime',
-        'expires_at' => 'datetime',
-    ];
+    protected function casts()
+    {
+        return [
+            'abilities' => 'json',
+            'last_used_at' => 'datetime',
+            'expires_at' => 'datetime',
+        ];
+    }
 
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',
@@ -33,7 +36,7 @@ class PersonalAccessToken extends Model implements HasAbilities
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $hidden = [
         'token',

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -8,20 +8,6 @@ use Laravel\Sanctum\Contracts\HasAbilities;
 class PersonalAccessToken extends Model implements HasAbilities
 {
     /**
-     * The attributes that should be cast to native types.
-     *
-     * @return array<string, string>
-     */
-    protected function casts()
-    {
-        return [
-            'abilities' => 'json',
-            'last_used_at' => 'datetime',
-            'expires_at' => 'datetime',
-        ];
-    }
-
-    /**
      * The attributes that are mass assignable.
      *
      * @var array<int, string>
@@ -92,5 +78,19 @@ class PersonalAccessToken extends Model implements HasAbilities
     public function cant($ability)
     {
         return ! $this->can($ability);
+    }
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @return array<string, string>
+     */
+    protected function casts()
+    {
+        return [
+            'abilities' => 'json',
+            'last_used_at' => 'datetime',
+            'expires_at' => 'datetime',
+        ];
     }
 }

--- a/tests/Unit/PersonalAccessTokenTest.php
+++ b/tests/Unit/PersonalAccessTokenTest.php
@@ -27,4 +27,20 @@ class PersonalAccessTokenTest extends TestCase
         $this->assertTrue($token->can('foo'));
         $this->assertTrue($token->can('bar'));
     }
+
+    public function test_extended_token_can_merge_parent_casts()
+    {
+        $extendedToken = new ExtendedPersonalAccessToken();
+
+        $this->assertArrayHasKey('is_impersonation', $extendedToken->getCasts());
+        $this->assertEquals('bool', $extendedToken->getCasts()['is_impersonation']);
+    }
+}
+
+class ExtendedPersonalAccessToken extends PersonalAccessToken
+{
+    protected function casts()
+    {
+        return parent::casts() + ['is_impersonation' => 'bool'];
+    }
 }


### PR DESCRIPTION
I need to be able to add some additional columns to my `personal_access_tokens` table. This makes it possible that I can do the following:

```php
class TeamworksToken extends PersonalAccessToken
{
    protected function casts()
    {
        return parent::casts() + ['is_impersonation' => 'bool'];
    }
}
```