### PR TITLE
[4.x] Add Generics to `HasApiTokens`

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -5,19 +5,22 @@ namespace Laravel\Sanctum;
 use DateTimeInterface;
 use Illuminate\Support\Str;
 
+/**
+ * @template TTokenModel of \Illuminate\Database\Eloquent\Model&\Laravel\Sanctum\Contracts\HasAbilities
+ */
 trait HasApiTokens
 {
     /**
      * The access token the user is using for the current request.
      *
-     * @var \Laravel\Sanctum\Contracts\HasAbilities
+     * @var TTokenModel
      */
     protected $accessToken;
 
     /**
      * Get the access tokens that belong to model.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<TTokenModel, $this>
      */
     public function tokens()
     {
@@ -75,7 +78,7 @@ trait HasApiTokens
     /**
      * Get the access token currently associated with the user.
      *
-     * @return \Laravel\Sanctum\Contracts\HasAbilities
+     * @return TTokenModel
      */
     public function currentAccessToken()
     {
@@ -85,7 +88,7 @@ trait HasApiTokens
     /**
      * Set the current access token for the user.
      *
-     * @param  \Laravel\Sanctum\Contracts\HasAbilities  $accessToken
+     * @param  TTokenModel  $accessToken
      * @return $this
      */
     public function withAccessToken($accessToken)

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -6,7 +6,7 @@ use DateTimeInterface;
 use Illuminate\Support\Str;
 
 /**
- * @template TTokenModel of \Illuminate\Database\Eloquent\Model&\Laravel\Sanctum\Contracts\HasAbilities
+ * @template TTokenModel of \Illuminate\Database\Eloquent\Model&\Laravel\Sanctum\Contracts\HasAbilities = \Laravel\Sanctum\PersonalAccessToken
  */
 trait HasApiTokens
 {


### PR DESCRIPTION
This adds generics to `HasApiTokens` to aid in static analysis.

This should be beneficial to folks who are overriding the default Sanctum models [as outlined in the docs](https://laravel.com/docs/11.x/sanctum#overriding-default-models), but also should provide IDE typehint && static analysis benefits.

If you are overriding the personal access token model, then you would add this to your tokenable model.

```php
class User extends Authenticatable
{
    /** @use HasApiTokens<TeamworksAccessToken> */
    use HasApiTokens;

    // ...
}
```

Otherwise, the default for the generic is already set.

As a bonus, it also adds the generics for `tokens()` relationship to keep in line with Laravel's MorphMany's generics.

## Outstanding Question
Should the same generics be added to the Contracts/HasApiTokens interface? 🤔 