### PR TITLE
[4.x] Use method instead of array for casts on `User`

### DIFF
--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -32,11 +32,14 @@ class User extends Authenticatable implements HasApiTokensContract
     ];
 
     /**
-     * The attributes that should be cast.
+     * The attributes that should be cast to native types.
      *
-     * @var array<string, string>
+     * @return array<string, string>
      */
-    protected $casts = [
-        'email_verified_at' => 'datetime',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+        ];
+    }
 }


### PR DESCRIPTION

This MR updates the `User` model to use the current preferred method of attribute casting. 
It uses `casts()` method instead of old way of using `casts` property.