### PR TITLE
Remove default `authenticate_session` middleware

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -75,7 +75,7 @@ return [
     */
 
     'middleware' => [
-        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
+        'authenticate_session' => null,
         'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
         'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
     ],

--- a/tests/Controller/FrontendRequestsAreStatefulTest.php
+++ b/tests/Controller/FrontendRequestsAreStatefulTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Sanctum\Tests\Controller;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
+use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 use Laravel\Sanctum\Sanctum;
 use Orchestra\Testbench\Concerns\WithWorkbench;
@@ -23,6 +24,7 @@ class FrontendRequestsAreStatefulTest extends TestCase
             'auth.guards.sanctum.provider' => 'users',
             'auth.providers.users.model' => User::class,
             'database.default' => 'testing',
+            'sanctum.middleware.authenticate_session' => AuthenticateSession::class,
             'sanctum.middleware.encrypt_cookies' => \Illuminate\Cookie\Middleware\EncryptCookies::class,
             'sanctum.middleware.verify_csrf_token' => \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
         ]);


### PR DESCRIPTION
This PR removes the default `authenticate_session` middleware that is set by Sanctum.

We ran into a hard to debug issue in our application where the user would be logged out immediately after impersonating _some_ users via Nova. As it turns out the "some" ended up being based on if the users shared the same password or not. So locally, everything worked fine as all seeded users get the same password. But in production, this is not the case.

I think another potential update here would be to keep the default config as-is, but update the Sanctum docs to make it clear what the `AuthenticateSession` middleware does, and that it is enabled by default. However, it seems like all other areas of the Laravel ecosystem make the "log out other devices" feature opt-in, instead of opt-out.