### PR TITLE
[4.x] Remove generic requirement that token is an instance of a Model

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -6,21 +6,21 @@ use DateTimeInterface;
 use Illuminate\Support\Str;
 
 /**
- * @template TTokenModel of \Illuminate\Database\Eloquent\Model&\Laravel\Sanctum\Contracts\HasAbilities = \Laravel\Sanctum\PersonalAccessToken
+ * @template TToken of Laravel\Sanctum\Contracts\HasAbilities = \Laravel\Sanctum\PersonalAccessToken
  */
 trait HasApiTokens
 {
     /**
      * The access token the user is using for the current request.
      *
-     * @var TTokenModel
+     * @var TToken
      */
     protected $accessToken;
 
     /**
      * Get the access tokens that belong to model.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<TTokenModel, $this>
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<TToken, $this>
      */
     public function tokens()
     {
@@ -78,7 +78,7 @@ trait HasApiTokens
     /**
      * Get the access token currently associated with the user.
      *
-     * @return TTokenModel
+     * @return TToken
      */
     public function currentAccessToken()
     {
@@ -88,7 +88,7 @@ trait HasApiTokens
     /**
      * Set the current access token for the user.
      *
-     * @param  TTokenModel  $accessToken
+     * @param  TToken  $accessToken
      * @return $this
      */
     public function withAccessToken($accessToken)

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -5,14 +5,14 @@ namespace Laravel\Sanctum;
 use Mockery;
 
 /**
- * @template TTokenModel of \Illuminate\Database\Eloquent\Model&\Laravel\Sanctum\Contracts\HasAbilities = \Laravel\Sanctum\PersonalAccessToken
+ * @template TToken of \Laravel\Sanctum\Contracts\HasAbilities = \Laravel\Sanctum\PersonalAccessToken
  */
 class Sanctum
 {
     /**
      * The personal access client model class name.
      *
-     * @var class-string<TTokenModel>
+     * @var class-string<TToken>
      */
     public static $personalAccessTokenModel = 'Laravel\\Sanctum\\PersonalAccessToken';
 
@@ -78,7 +78,7 @@ class Sanctum
     /**
      * Set the personal access token model name.
      *
-     * @param  class-string<TTokenModel>  $model
+     * @param  class-string<TToken>  $model
      * @return void
      */
     public static function usePersonalAccessTokenModel($model)
@@ -111,7 +111,7 @@ class Sanctum
     /**
      * Get the token model class name.
      *
-     * @return class-string<TTokenModel>
+     * @return class-string<TToken>
      */
     public static function personalAccessTokenModel()
     {


### PR DESCRIPTION
As pointed out by @unre4l in [this comment](https://github.com/laravel/sanctum/pull/544#issuecomment-2498319098), there's no requirement that the token is an instance of an Eloquent model.