### PR TITLE
Add leading slash to @template tag in HasTokens

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -6,7 +6,7 @@ use DateTimeInterface;
 use Illuminate\Support\Str;
 
 /**
- * @template TToken of Laravel\Sanctum\Contracts\HasAbilities = \Laravel\Sanctum\PersonalAccessToken
+ * @template TToken of \Laravel\Sanctum\Contracts\HasAbilities = \Laravel\Sanctum\PersonalAccessToken
  */
 trait HasApiTokens
 {


### PR DESCRIPTION
Psalm on my project got confused when it was taken away, reporting:
```
ERROR: UndefinedClass - app/Models/User.php:31:7 - Class, interface or enum named Laravel\Sanctum\Laravel\Sanctum\Contracts\HasAbilities does not exist (see https://psalm.dev/019)
class User extends Authenticatable
```
essentially doubling up the namespace.
