### PR TITLE
[4.x] Add `tokenCant()` helper function to `HasApiTokens`

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -39,6 +39,17 @@ trait HasApiTokens
     }
 
     /**
+     * Determine if the current API token does not have a given scope.
+     *
+     * @param  string  $ability
+     * @return bool
+     */
+    public function tokenCant(string $ability)
+    {
+        return $this->accessToken && $this->accessToken->cant($ability);
+    }
+
+    /**
      * Create a new personal access token for the user.
      *
      * @param  string  $name

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -46,7 +46,7 @@ trait HasApiTokens
      */
     public function tokenCant(string $ability)
     {
-        return $this->accessToken && $this->accessToken->cant($ability);
+        return ! $this->tokenCan($ability);
     }
 
     /**

--- a/tests/Feature/HasApiTokensTest.php
+++ b/tests/Feature/HasApiTokensTest.php
@@ -61,7 +61,6 @@ class HasApiTokensTest extends TestCase
         $this->assertFalse($class->tokenCant('foo'));
     }
 
-
     public function test_token_checksum_is_valid()
     {
         $config = require __DIR__.'/../../config/sanctum.php';

--- a/tests/Feature/HasApiTokensTest.php
+++ b/tests/Feature/HasApiTokensTest.php
@@ -48,6 +48,20 @@ class HasApiTokensTest extends TestCase
         $this->assertTrue($class->tokenCan('foo'));
     }
 
+    public function test_check_token_cant_ability()
+    {
+        $class = new ClassThatHasApiTokens;
+
+        $newToken = $class->createToken('test', ['foo']);
+
+        $class->withAccessToken($newToken->accessToken);
+
+        $this->assertTrue($class->tokenCant('bar'));
+
+        $this->assertFalse($class->tokenCant('foo'));
+    }
+
+
     public function test_token_checksum_is_valid()
     {
         $config = require __DIR__.'/../../config/sanctum.php';


### PR DESCRIPTION
This PR adds `tokenCant()` helper function to the `HasApiTokens` trait. It allows you to check if the accessToken does not have an ability. It is the opposite of the current `tokenCan` helper function.

```
    public function tokenCant(string $ability)
    {
        return ! $this->tokenCan($ability);
    }
```

It will be helpful to people who want to do something if a token does not have the ability, for example:

```
abort_if($user->tokenCant('foo'), 403)
```

I think its a bit more readable than:

```
abort_if(! $user->tokenCan('foo'), 403)
```

It won't break any existing features as this PR does not change any existing code.