### PR TITLE
Defer updating of last_used_at

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -80,12 +80,12 @@ class Guard
             if (method_exists($accessToken->getConnection(), 'hasModifiedRecords') &&
                 method_exists($accessToken->getConnection(), 'setRecordModificationState')) {
                 tap($accessToken->getConnection()->hasModifiedRecords(), function ($hasModifiedRecords) use ($accessToken) {
-                    defer(fn() => $accessToken->forceFill(['last_used_at' => now()])->save())->always();
+                    defer(fn () => $accessToken->forceFill(['last_used_at' => now()])->save())->always();
 
                     $accessToken->getConnection()->setRecordModificationState($hasModifiedRecords);
                 });
             } else {
-                defer(fn() => $accessToken->forceFill(['last_used_at' => now()])->save())->always();
+                defer(fn () => $accessToken->forceFill(['last_used_at' => now()])->save())->always();
             }
 
             return $tokenable;

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -80,12 +80,12 @@ class Guard
             if (method_exists($accessToken->getConnection(), 'hasModifiedRecords') &&
                 method_exists($accessToken->getConnection(), 'setRecordModificationState')) {
                 tap($accessToken->getConnection()->hasModifiedRecords(), function ($hasModifiedRecords) use ($accessToken) {
-                    $accessToken->forceFill(['last_used_at' => now()])->save();
+                    defer(fn() => $accessToken->forceFill(['last_used_at' => now()])->save())->always();
 
                     $accessToken->getConnection()->setRecordModificationState($hasModifiedRecords);
                 });
             } else {
-                $accessToken->forceFill(['last_used_at' => now()])->save();
+                defer(fn() => $accessToken->forceFill(['last_used_at' => now()])->save())->always();
             }
 
             return $tokenable;

--- a/tests/Feature/GuardTest.php
+++ b/tests/Feature/GuardTest.php
@@ -157,6 +157,7 @@ class GuardTest extends TestCase
             'expires_at' => now()->addMinutes(60),
         ]);
 
+        $this->withoutDefer();
         $returnedUser = $guard->__invoke($request);
 
         $this->assertEquals($user->id, $returnedUser->id);
@@ -187,6 +188,7 @@ class GuardTest extends TestCase
             'name' => 'Test',
         ]);
 
+        $this->withoutDefer();
         $returnedUser = $guard->__invoke($request);
 
         $this->assertEquals($user->id, $returnedUser->id);
@@ -331,6 +333,7 @@ class GuardTest extends TestCase
             return $request->header('X-Auth-Token');
         });
 
+        $this->withoutDefer();
         $returnedUser = $guard->__invoke($request);
 
         $this->assertEquals($user->id, $returnedUser->id);


### PR DESCRIPTION
Currently, the `last_used_at` field is updated immediately, which could be replaced with the deferred approach.