### PR TITLE
fix: multiple guard select

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -54,7 +54,12 @@ class Guard
     public function __invoke(Request $request)
     {
         foreach (Arr::wrap(config('sanctum.guard', 'web')) as $guard) {
-            if ($user = $this->auth->guard($guard)->user()) {
+            $user = $this->auth->guard($guard)->user();
+            if (! $user) {
+                continue;
+            }
+
+            if (is_null($this->provider) || $this->hasValidProvider($user)) {
                 return $this->supportsTokens($user)
                     ? $user->withAccessToken(new TransientToken)
                     : $user;


### PR DESCRIPTION
When we've guards like this:

```php
// config/auth.php
'guards' => [
        'web' => [
            'driver' => 'session',
            'provider' => 'users',
        ],
        'api' => [
            'driver' => 'sanctum',
            'provider' => 'users',
        ],
        'admin' => [
            'driver' => 'session',
            'provider' => 'admins',
        ],
        'admin-api' => [
            'driver' => 'sanctum',
            'provider' => 'admins',
        ],
    ],
```

and sanctum config:
```php
// config/sanctum.php
'guard' => ['web', 'admin'],
```

and using middleware like this: 
```php
Route::group(['middleware' => 'auth:web,api'], ...);
Route::group(['middleware' => 'auth:admin,admin-api'], ...);
```

It was always pick the default `web` guard, and never going to correct and use the `admin` or `admin-api` guard on the scope.

So, I patched this to fix  that issue and use correct guard always.