### PR TITLE
Allow custom middlewares into EnsureFrontendRequestsAreStateful

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -75,8 +75,10 @@ return [
     */
 
     'middleware' => [
+        'add_queued_cookies_to_response' => Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
         'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
         'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
+        'start_session' => Illuminate\Session\Middleware\StartSession::class,
         'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
     ],
 

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -48,8 +48,8 @@ class EnsureFrontendRequestsAreStateful
     {
         $middleware = array_values(array_filter(array_unique([
             config('sanctum.middleware.encrypt_cookies', \Illuminate\Cookie\Middleware\EncryptCookies::class),
-            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
+            config('sanctum.middleware.add_queued_cookies_to_response', \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class),
+            config('sanctum.middleware.start_session', \Illuminate\Session\Middleware\StartSession::class),
             config('sanctum.middleware.validate_csrf_token', config('sanctum.middleware.verify_csrf_token', \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class)),
             config('sanctum.middleware.authenticate_session'),
         ])));


### PR DESCRIPTION
This PR enables the use of customized middlewares with EnsureFrontendRequestsAreStateful.

In a Laravel project where Illuminate\Session\Middleware\StartSession is replaced with a custom middleware, EnsureFrontendRequestsAreStateful was still using the default middleware.

This change will benefit developers who want to replace the default middlewares with their custom implementations.

Problem Description
In a Laravel + Sanctum project configured as follows:

```
<?php
return Application::configure(basePath: dirname(__DIR__))
    ->withMiddleware(static function (Middleware $middleware): void {
        $middleware->web(
            replace: [
                StartSession::class => CustomStartSession::class,
            ],
        );

        $middleware->statefulApi();
        // ...
});
```

The routes under api group does not use the custom StartSession, and EnsureFrontendRequestsAreStateful uses the default hardcoded middleware. This forces developers to copy and paste the frontendMiddleware method, risking it becoming out of sync with future updates to Sanctum.

Additionally, all other middleware used by EnsureFrontendRequestsAreStateful are already configurable.