### PR TITLE
Dynamically includin the request http host as a stateful domain

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -23,6 +23,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Include Request Host as stateful domain
+    |--------------------------------------------------------------------------
+    |
+    | In most cases frontend SPA implementations call API endpoints on the
+    | same domain name the SPA is hosted from.  This parameter enables
+    | you to dynamically include the request host as stateful domain.
+    |
+    */
+
+    'same_domain_stateful' => env('SANCTUM_SAME_DOMAIN_STATEFUL', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Sanctum Guards
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -83,6 +83,10 @@ class EnsureFrontendRequestsAreStateful
 
         $stateful = array_filter(config('sanctum.stateful', []));
 
+        if(config('sanctum.same_domain_stateful')) {
+            $stateful[] = $request->getHttpHost();
+        }
+
         return Str::is(Collection::make($stateful)->map(function ($uri) {
             return trim($uri).'/*';
         })->all(), $domain);

--- a/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
@@ -59,6 +59,19 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
 
+    public function test_same_domain_stateful()
+    {
+        $request = Request::create('https://app-domain.com/');
+        $request->headers->set('origin', 'app-domain.com');
+
+        config(['sanctum.same_domain_stateful' => false]);
+        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+        config(['sanctum.same_domain_stateful' => true]);
+        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+    }
+
     public function test_wildcard_matching()
     {
         $request = Request::create('/');


### PR DESCRIPTION
When running an application that is hosted from multiple domain names which can be dynamically added to the system, sanctum currently doesn't support dynamically adding these domain names to the stateful domain list in the configuration file (since configuration is cached).

However, since our frontend is always caling the API on the same domain, treating the request http host as one of the domain names to be considered stateful, would solve this issue.

Personally, I didn't really see a case where a domain name request coming from the same domain as the backend server should not be considered a stateful SPA request, but I contributed the change by introducing a new configuration parameter that allows you to activate the feature from within configuration as to remain backwards compatible by default.