### PR TITLE
Feature to treat same domain requests to be from frontend and make stateful

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -12,27 +12,17 @@ return [
     | Requests from the following domains / hosts will receive stateful API
     | authentication cookies. Typically, these should include your local
     | and production domains which access your API via a frontend SPA.
+    | Sanctum::currentRequestHost() instructs Sanctum to include the
+    | request host from the current request in the stateful list.
     |
     */
 
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
-        Sanctum::currentApplicationUrlWithPort()
+        Sanctum::currentApplicationUrlWithPort(),
+        // Sanctum::currentRequestHost(),
     ))),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Include Request Host as stateful domain
-    |--------------------------------------------------------------------------
-    |
-    | In most cases frontend SPA implementations call API endpoints on the
-    | same domain name the SPA is hosted from.  This parameter enables
-    | you to dynamically include the request host as stateful domain.
-    |
-    */
-
-    'same_domain_stateful' => env('SANCTUM_SAME_DOMAIN_STATEFUL', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -23,6 +23,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Include Request Host as stateful domain
+    |--------------------------------------------------------------------------
+    |
+    | In most cases frontend SPA implementations call API endpoints on the
+    | same domain name the SPA is hosted from.  This parameter enables
+    | you to dynamically include the request host as stateful domain.
+    |
+    */
+
+    'same_domain_stateful' => env('SANCTUM_SAME_DOMAIN_STATEFUL', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Sanctum Guards
     |--------------------------------------------------------------------------
     |

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -12,8 +12,6 @@ return [
     | Requests from the following domains / hosts will receive stateful API
     | authentication cookies. Typically, these should include your local
     | and production domains which access your API via a frontend SPA.
-    | Sanctum::currentRequestHost() instructs Sanctum to include the
-    | request host from the current request in the stateful list.
     |
     */
 

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -83,7 +83,7 @@ class EnsureFrontendRequestsAreStateful
 
         $stateful = array_filter(config('sanctum.stateful', []));
 
-        if(config('sanctum.same_domain_stateful')) {
+        if (config('sanctum.same_domain_stateful')) {
             $stateful[] = $request->getHttpHost();
         }
 

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -86,6 +86,7 @@ class EnsureFrontendRequestsAreStateful
 
         return Str::is(Collection::make($stateful)->map(function ($uri) use ($request) {
             $uri = $uri === Sanctum::currentRequestHost() ? $request->getHttpHost() : $uri;
+
             return trim($uri).'/*';
         })->all(), $domain);
     }

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -83,6 +83,10 @@ class EnsureFrontendRequestsAreStateful
 
         $stateful = array_filter(config('sanctum.stateful', []));
 
+        if(config('sanctum.same_domain_stateful')) {
+            $stateful[] = $request->getHttpHost();
+        }
+
         return Str::is(Collection::make($stateful)->map(function ($uri) {
             return trim($uri).'/*';
         })->all(), $domain);

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -5,6 +5,7 @@ namespace Laravel\Sanctum\Http\Middleware;
 use Illuminate\Routing\Pipeline;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
 
 class EnsureFrontendRequestsAreStateful
 {
@@ -83,11 +84,8 @@ class EnsureFrontendRequestsAreStateful
 
         $stateful = array_filter(config('sanctum.stateful', []));
 
-        if (config('sanctum.same_domain_stateful')) {
-            $stateful[] = $request->getHttpHost();
-        }
-
-        return Str::is(Collection::make($stateful)->map(function ($uri) {
+        return Str::is(Collection::make($stateful)->map(function ($uri) use ($request) {
+            $uri = $uri === Sanctum::currentRequestHost() ? $request->getHttpHost() : $uri;
             return trim($uri).'/*';
         })->all(), $domain);
     }

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -43,7 +43,7 @@ class Sanctum
     }
 
     /**
-     * Get a fixed token instructing Sanctum to include the current request Url in the list of stateful domains.
+     * Get a fixed token instructing Sanctum to include the current request host in the list of stateful domains.
      *
      * @return string
      */

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -43,6 +43,16 @@ class Sanctum
     }
 
     /**
+     * Get a fixed token instructing Sanctum to include the current request Url in the list of stateful domains.
+     *
+     * @return string
+     */
+    public static function currentRequestHost()
+    {
+        return '__SANCTUM_CURRENT_REQUEST_HOST__';
+    }
+
+    /**
      * Set the current user for the application with the given abilities.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|\Laravel\Sanctum\HasApiTokens  $user

--- a/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Sanctum\Tests\Feature;
 
 use Illuminate\Http\Request;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Laravel\Sanctum\Sanctum;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 
@@ -64,10 +65,10 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $request = Request::create('https://app-domain.com/');
         $request->headers->set('origin', 'app-domain.com');
 
-        config(['sanctum.same_domain_stateful' => false]);
+        config(['sanctum.stateful' => []]);
         $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
 
-        config(['sanctum.same_domain_stateful' => true]);
+        config(['sanctum.stateful' => [Sanctum::currentRequestHost()]]);
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
 

--- a/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
@@ -69,7 +69,6 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
 
         config(['sanctum.same_domain_stateful' => true]);
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
-
     }
 
     public function test_wildcard_matching()

--- a/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
@@ -59,6 +59,19 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
 
+    public function test_same_domain_stateful()
+    {
+        $request = Request::create('https://app-domain.com/');
+        $request->headers->set('origin', 'app-domain.com');
+
+        config(['sanctum.same_domain_stateful' => false]);
+        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+        config(['sanctum.same_domain_stateful' => true]);
+        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+
+    }
+
     public function test_wildcard_matching()
     {
         $request = Request::create('/');


### PR DESCRIPTION
Our application is running under multiple domain names (multi tenant), each domain name hosting an SPA which communicates to the API endpoints under their own domain name as well.

In order to make sure that Sanctum recognizes these incoming requests as coming from the frontend, today we can only add them to the configuration file, which is cached, and which makes it cumbersome when we want to have that automatcally updated when a user adds a new domain name.

So we were looking into how we could resolve this by overriding the default behaviour of the middleware fromFrontend() method to dynamically check against the tenant host names in our database, but while doing so we actually came to the conclusion that in fact any call that is from the same domain (the referer / origin matches the request host), should be considered as being from the SPA frontend and therefore be made stateful.

Personally, I don't really see a case where this logic would not be applicable, and maybe this could be included into the standard behaviour, but as I'm sure this was thought through when implemented initially, I probably overlook a reason as to why you might not want this behaviour, so I made this PR backwards compatible, by adding a config parameter to enable this behaviour, so it remains disabled by default, and this can be released in a minor.