### PR TITLE
Fixes inconsistency in Sanctum::currentApplicationUrlWithPort() and Sanctum::currentRequestHost()

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -85,7 +85,7 @@ class EnsureFrontendRequestsAreStateful
         $stateful = array_filter(config('sanctum.stateful', []));
 
         return Str::is(Collection::make($stateful)->map(function ($uri) use ($request) {
-            $uri = $uri === Sanctum::currentRequestHost() ? $request->getHttpHost() : $uri;
+            $uri = $uri === Sanctum::$currentRequestHostPlaceholder ? $request->getHttpHost() : $uri;
 
             return trim($uri).'/*';
         })->all(), $domain);

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -56,7 +56,7 @@ class Sanctum
      */
     public static function currentRequestHost()
     {
-        return ',' . static::$currentRequestHostPlaceholder;
+        return ','.static::$currentRequestHostPlaceholder;
     }
 
     /**

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -31,6 +31,13 @@ class Sanctum
     public static $accessTokenAuthenticationCallback;
 
     /**
+     * A placeholder to instruct Sanctum to include the current request host in the list of stateful domains.
+     *
+     * @var string;
+     */
+    public static $currentRequestHostPlaceholder = '__SANCTUM_CURRENT_REQUEST_HOST__';
+
+    /**
      * Get the current application URL from the "APP_URL" environment variable - with port.
      *
      * @return string
@@ -49,7 +56,7 @@ class Sanctum
      */
     public static function currentRequestHost()
     {
-        return '__SANCTUM_CURRENT_REQUEST_HOST__';
+        return ',' . static::$currentRequestHostPlaceholder;
     }
 
     /**

--- a/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
@@ -68,7 +68,7 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         config(['sanctum.stateful' => []]);
         $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
 
-        config(['sanctum.stateful' => [Sanctum::currentRequestHost()]]);
+        config(['sanctum.stateful' => [Sanctum::$currentRequestHostPlaceholder]]);
         $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
     }
 


### PR DESCRIPTION
When submitting https://github.com/laravel/sanctum/pull/564, I didn't include a test using the actual config file.
Pulling in the new version to day, I noticed there was an issue with using it in the config as follows:

```php
'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
    '%s%s%s',
    'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
    Sanctum::currentApplicationUrlWithPort(),
    Sanctum::currentRequestHost()
))),
```

The problem is, that `Sanctum::currentApplicationUrlWithPort()` prepends the url with a comma, so it can be used here in the config.

personally, I don't like the prepend for the sake of making it usable in the `explode(sprintf())` here, and would remove it, but that would be a breaking change, so I changed the implementation of the `Sanctum::currentRequestHost()` to be in line with how `Sanctum::currentApplicationUrlWithPort()` works, so this can be used in the same way.

My apologies for the oversight.