### PR TITLE
fix: add missing comma separator in stateful domains configuration

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -16,7 +16,7 @@ return [
     */
 
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
-        '%s%s',
+        '%s,%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         Sanctum::currentApplicationUrlWithPort(),
         // Sanctum::currentRequestHost(),


### PR DESCRIPTION
## Description

### Problem
The default `stateful` domains configuration in `config/sanctum.php` contains a bug in the `sprintf` call that concatenates the base domain list with the application URL without a proper comma separator. This causes domains to merge incorrectly, potentially breaking CORS and stateful authentication.

### Root Cause
In lines 18-23 of the default Sanctum configuration, the `sprintf` format string uses `'%s%s'` instead of `'%s,%s'`:

```php
'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
    '%s%s',  // Missing comma separator
    'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
    Sanctum::currentApplicationUrlWithPort(),
))),
```

### Impact
This results in malformed domain lists. For example:
- **Incorrect output**: `localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1example.com:8080`
- **Correct output**: `localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1,example.com:8080`

The missing comma causes:
1. The last default domain (`::1`) and the application URL to merge into a single invalid domain
2. CORS failures when the application URL doesn't match any valid stateful domain
3. Stateful authentication issues in production environments

### Solution
Add a comma in the `sprintf` format string:

```php
'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
    '%s,%s',  // Added comma separator
    'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
    Sanctum::currentApplicationUrlWithPort(),
))),
```

### Testing
- Verified that `explode(',', ...)` now correctly splits all domains including the application URL
- Confirmed CORS requests work properly with the application URL
- Tested with various application URLs (with and without ports)

### Breaking Changes
None. This is a bug fix that corrects existing behavior without changing the API or expected functionality.