### PR TITLE
[4.x] Factor token `last_used_at` update into separate method

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -185,11 +185,10 @@ class Guard
     {
         if (method_exists($accessToken->getConnection(), 'hasModifiedRecords') &&
             method_exists($accessToken->getConnection(), 'setRecordModificationState')) {
-            tap($accessToken->getConnection()->hasModifiedRecords(), function ($hasModifiedRecords) use ($accessToken) {
-                $accessToken->forceFill(['last_used_at' => now()])->save();
+            $hasModifiedRecords = $accessToken->getConnection()->hasModifiedRecords();
+            $accessToken->forceFill(['last_used_at' => now()])->save();
 
-                $accessToken->getConnection()->setRecordModificationState($hasModifiedRecords);
-            });
+            $accessToken->getConnection()->setRecordModificationState($hasModifiedRecords);
         } else {
             $accessToken->forceFill(['last_used_at' => now()])->save();
         }

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -178,7 +178,7 @@ class Guard
     /**
      * Store the time the token was last used.
      *
-     * @param \Laravel\Sanctum\PersonalAccessToken $accessToken
+     * @param  \Laravel\Sanctum\PersonalAccessToken  $accessToken
      * @return void
      */
     protected function updateLastUsedAt($accessToken)

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -77,16 +77,7 @@ class Guard
 
             event(new TokenAuthenticated($accessToken));
 
-            if (method_exists($accessToken->getConnection(), 'hasModifiedRecords') &&
-                method_exists($accessToken->getConnection(), 'setRecordModificationState')) {
-                tap($accessToken->getConnection()->hasModifiedRecords(), function ($hasModifiedRecords) use ($accessToken) {
-                    $accessToken->forceFill(['last_used_at' => now()])->save();
-
-                    $accessToken->getConnection()->setRecordModificationState($hasModifiedRecords);
-                });
-            } else {
-                $accessToken->forceFill(['last_used_at' => now()])->save();
-            }
+            $this->updateLastUsedAt($accessToken);
 
             return $tokenable;
         }
@@ -182,5 +173,25 @@ class Guard
         $model = config("auth.providers.{$this->provider}.model");
 
         return $tokenable instanceof $model;
+    }
+
+    /**
+     * Store the time the token was last used.
+     *
+     * @param \Laravel\Sanctum\PersonalAccessToken $accessToken
+     * @return void
+     */
+    protected function updateLastUsedAt($accessToken)
+    {
+        if (method_exists($accessToken->getConnection(), 'hasModifiedRecords') &&
+            method_exists($accessToken->getConnection(), 'setRecordModificationState')) {
+            tap($accessToken->getConnection()->hasModifiedRecords(), function ($hasModifiedRecords) use ($accessToken) {
+                $accessToken->forceFill(['last_used_at' => now()])->save();
+
+                $accessToken->getConnection()->setRecordModificationState($hasModifiedRecords);
+            });
+        } else {
+            $accessToken->forceFill(['last_used_at' => now()])->save();
+        }
     }
 }


### PR DESCRIPTION
For apps that are high usage or perhaps just don't want the overhead of performing an UPDATE query on every API request, avoiding the update to `personal_access_tokens.last_used_at` requires extending the Guard class, but copying over the entirety of the `__invoke()` method.

I was considering writing this to Redis or just not writing it at all, as we have app usage visibility in other places.

Other options:
1. Make the token update happen in reaction to the `TokenAuthenticated` event. This separates concerns nicely, however, it _could_ be a breaking change if userland listeners depend on the model being updated but events are now handled out of order. Definitely a minor concern in my eyes, but a possible risk nonetheless.
2. Add a method to `PersonalAccessToken` like `updateLastUsed()` and call that instead of the forceFill inside of `Guard@__invoke()` In the app I'm work on, we've already extended the PersonalAccessToken. Here I might choose to write to Redis instead, or just make the function a no-op.
3. Move the token updating to a separate class and make it something configurable on the `Sanctum` class, akin to `$personalAccessTokenModel`, `$accessTokenRetrievalCallback`, etc.