### PR TITLE
[3x] fix Implicitly nullable parameters are deprecated.

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -128,7 +128,7 @@ class Guard
      * @param  string|null  $token
      * @return bool
      */
-    protected function isValidBearerToken(string $token = null)
+    protected function isValidBearerToken(?string $token = null)
     {
         if (! is_null($token) && str_contains($token, '|')) {
             $model = new Sanctum::$personalAccessTokenModel;


### PR DESCRIPTION
I know Laravel 10 lost the support, but this is a slight adjustment so as not to generate more boring depreciation errors, please take advantage

> ErrorException: Laravel\Sanctum\Guard::isValidBearerToken(): Implicitly marking parameter $token as nullable is deprecated, the explicit nullable type must be used instead in /var/task/vendor/laravel/sanctum/src/Guard.php:131
Stack trace:
#0 /var/task/vendor/laravel/framework/src/Illuminate/Support/helpers.php(445): Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::handleDeprecationError():102}(Object(Illuminate\Log\Logger))