### PR TITLE
Refactor: Extract Frontend Request Checking Logic

### DIFF
--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -3,7 +3,6 @@
 namespace Laravel\Sanctum\Http\Middleware;
 
 use Illuminate\Routing\Pipeline;
-use Illuminate\Support\Arr;
 
 class EnsureFrontendRequestsAreStateful
 {

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -3,9 +3,7 @@
 namespace Laravel\Sanctum\Http\Middleware;
 
 use Illuminate\Routing\Pipeline;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
-use Laravel\Sanctum\Sanctum;
+use Illuminate\Support\Arr;
 
 class EnsureFrontendRequestsAreStateful
 {
@@ -20,11 +18,16 @@ class EnsureFrontendRequestsAreStateful
     {
         $this->configureSecureCookieSessions();
 
-        return (new Pipeline(app()))->send($request)->through(
-            static::fromFrontend($request) ? $this->frontendMiddleware() : []
-        )->then(function ($request) use ($next) {
-            return $next($request);
-        });
+        $middleware = FrontendRequestChecker::isFromFrontend($request)
+            ? $this->frontendMiddleware()
+            : [];
+
+        return (new Pipeline(app()))
+            ->send($request)
+            ->through($middleware)
+            ->then(function ($request) use ($next) {
+                return $next($request);
+            });
     }
 
     /**
@@ -62,32 +65,5 @@ class EnsureFrontendRequestsAreStateful
         });
 
         return $middleware;
-    }
-
-    /**
-     * Determine if the given request is from the first-party application frontend.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return bool
-     */
-    public static function fromFrontend($request)
-    {
-        $domain = $request->headers->get('referer') ?: $request->headers->get('origin');
-
-        if (is_null($domain)) {
-            return false;
-        }
-
-        $domain = Str::replaceFirst('https://', '', $domain);
-        $domain = Str::replaceFirst('http://', '', $domain);
-        $domain = Str::endsWith($domain, '/') ? $domain : "{$domain}/";
-
-        $stateful = array_filter(config('sanctum.stateful', []));
-
-        return Str::is(Collection::make($stateful)->map(function ($uri) use ($request) {
-            $uri = $uri === Sanctum::$currentRequestHostPlaceholder ? $request->getHttpHost() : $uri;
-
-            return trim($uri).'/*';
-        })->all(), $domain);
     }
 }

--- a/src/Http/Middleware/FrontendRequestChecker.php
+++ b/src/Http/Middleware/FrontendRequestChecker.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Laravel\Sanctum\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+
+class FrontendRequestChecker
+{
+    /**
+     * Determine if the given request is from the first-party application frontend.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public static function isFromFrontend(Request $request): bool
+    {
+        $domain = self::getDomain($request);
+
+        if (is_null($domain)) {
+            return false;
+        }
+
+        $stateful = array_filter(config('sanctum.stateful', []));
+
+        $patterns = self::getStatefulDomainPatterns($stateful, $request);
+
+        return Str::is($patterns, $domain);
+    }
+
+    /**
+     * Get the domain from the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string|null
+     */
+    private static function getDomain(Request $request): ?string
+    {
+        $domain = $request->headers->get('referer') ?: $request->headers->get('origin');
+
+        if (is_null($domain)) {
+            return null;
+        }
+
+        $domain = Str::of($domain)->after('://')->finish('/');
+
+        return (string) $domain;
+    }
+
+    /**
+     * Get the stateful domain patterns.
+     *
+     * @param  array  $stateful
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    private static function getStatefulDomainPatterns(array $stateful, Request $request): array
+    {
+        return Collection::make($stateful)->map(function ($uri) use ($request) {
+            if ($uri === Sanctum::$currentRequestHostPlaceholder) {
+                return trim($request->getHttpHost()).'/*';
+            }
+
+            return trim($uri).'/*';
+        })->all();
+    }
+}

--- a/tests/Feature/DefaultConfigContainsAppUrlTest.php
+++ b/tests/Feature/DefaultConfigContainsAppUrlTest.php
@@ -3,7 +3,7 @@
 namespace Laravel\Sanctum\Tests\Feature;
 
 use Illuminate\Http\Request;
-use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Laravel\Sanctum\Http\Middleware\FrontendRequestChecker;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 
@@ -52,6 +52,6 @@ class DefaultConfigContainsAppUrlTest extends TestCase
 
         $request->headers->set('referer', config('app.url'));
 
-        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertTrue(FrontendRequestChecker::isFromFrontend($request));
     }
 }

--- a/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
+++ b/tests/Feature/EnsureFrontendRequestsAreStatefulTest.php
@@ -3,7 +3,7 @@
 namespace Laravel\Sanctum\Tests\Feature;
 
 use Illuminate\Http\Request;
-use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Laravel\Sanctum\Http\Middleware\FrontendRequestChecker;
 use Laravel\Sanctum\Sanctum;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
@@ -22,22 +22,22 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $request = Request::create('/');
         $request->headers->set('referer', 'https://test.com');
 
-        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertTrue(FrontendRequestChecker::isFromFrontend($request));
 
         $request = Request::create('/');
         $request->headers->set('referer', 'https://wrong.com');
 
-        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertFalse(FrontendRequestChecker::isFromFrontend($request));
 
         $request = Request::create('/');
         $request->headers->set('referer', 'https://test.com.x');
 
-        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertFalse(FrontendRequestChecker::isFromFrontend($request));
 
         $request = Request::create('/');
         $request->headers->set('referer', 'https://foobar.test.com/');
 
-        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertTrue(FrontendRequestChecker::isFromFrontend($request));
     }
 
     public function test_request_origin_fallback()
@@ -45,19 +45,19 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $request = Request::create('/');
         $request->headers->set('origin', 'test.com');
 
-        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertTrue(FrontendRequestChecker::isFromFrontend($request));
 
         $request = Request::create('/');
         $request->headers->set('referer', null);
         $request->headers->set('origin', 'test.com');
 
-        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertTrue(FrontendRequestChecker::isFromFrontend($request));
 
         $request = Request::create('/');
         $request->headers->set('referer', '');
         $request->headers->set('origin', 'test.com');
 
-        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertTrue(FrontendRequestChecker::isFromFrontend($request));
     }
 
     public function test_same_domain_stateful()
@@ -66,10 +66,10 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $request->headers->set('origin', 'app-domain.com');
 
         config(['sanctum.stateful' => []]);
-        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertFalse(FrontendRequestChecker::isFromFrontend($request));
 
         config(['sanctum.stateful' => [Sanctum::$currentRequestHostPlaceholder]]);
-        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertTrue(FrontendRequestChecker::isFromFrontend($request));
     }
 
     public function test_wildcard_matching()
@@ -77,7 +77,7 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
         $request = Request::create('/');
         $request->headers->set('referer', 'https://foo.test.com');
 
-        $this->assertTrue(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertTrue(FrontendRequestChecker::isFromFrontend($request));
     }
 
     public function test_requests_are_not_stateful_without_referer()
@@ -86,6 +86,6 @@ class EnsureFrontendRequestsAreStatefulTest extends TestCase
 
         $request = Request::create('/');
 
-        $this->assertFalse(EnsureFrontendRequestsAreStateful::fromFrontend($request));
+        $this->assertFalse(FrontendRequestChecker::isFromFrontend($request));
     }
 }


### PR DESCRIPTION
This PR refactors the `EnsureFrontendRequestsAreStateful` middleware to improve its structure and adhere more closely to the Single Responsibility Principle.

### **Description**

The `EnsureFrontendRequestsAreStateful` middleware was previously responsible for two distinct tasks:

1.  Determining if a request originated from a stateful frontend domain.
2.  Applying the appropriate middleware pipeline based on that determination.

This refactor extracts the domain-checking logic into its own dedicated class, `FrontendRequestChecker`. This simplifies the middleware, making its sole responsibility to orchestrate the middleware pipeline.

### **Changes Made**

  - **New Class:** Added a new `Laravel\Sanctum\Http\Middleware\FrontendRequestChecker` class.
  - **Logic Extraction:** Moved the logic for parsing referer/origin headers and comparing them against the `stateful` configuration from `EnsureFrontendRequestsAreStateful::fromFrontend()` to the new `FrontendRequestChecker::isFromFrontend()` method.
  - **Middleware Simplification:** The `EnsureFrontendRequestsAreStateful` middleware now calls the new checker class. Its internal static method `fromFrontend()` has been removed.

### **Benefits of this Change**

  - **Improved Readability:** Each class now has a clear and focused purpose.
  - **Single Responsibility Principle:** The middleware is no longer concerned with the implementation details of *how* a request is identified as coming from the frontend.
  - **Enhanced Testability:** The `FrontendRequestChecker` can now be unit-tested in complete isolation, leading to simpler and more robust tests.