### PR TITLE
refactor: use text for name column

### DIFF
--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->id();
             $table->morphs('tokenable');
-            $table->string('name');
+            $table->text('name');
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();
             $table->timestamp('last_used_at')->nullable();


### PR DESCRIPTION
This MR updates the name column in the personal_access_tokens table from string to text.

The current string limit (255 characters) causes SQL truncation errors when storing long user agent strings, especially from in-app browsers like Instagram.

Example error:

`SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'name'`

Example user agent:

`Mozilla/5.0 (Linux; Android 14; SM-0000E Build/UP1A.000005.007; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/138.0.0004.45 Mobile Safari/537.36 Instagram 000.0.0.00.00 Android (34/14; 450dpi; 1080x2116; samsung; SM-0006E; a55x; s5e0000; en_GB; 746325133`