### PR TITLE
Allow null password hash

### DIFF
--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -110,11 +110,11 @@ class AuthenticateSession
      * Validate the password hash against the stored value.
      *
      * @param  \Illuminate\Auth\SessionGuard  $guard
-     * @param  string  $passwordHash
+     * @param  string|null  $passwordHash
      * @param  string  $storedValue
      * @return bool
      */
-    protected function validatePasswordHash(SessionGuard $guard, string $passwordHash, string $storedValue): bool
+    protected function validatePasswordHash(SessionGuard $guard, ?string $passwordHash, string $storedValue): bool
     {
         // Try new HMAC format first (Laravel 12.45.0+)...
         if (method_exists($guard, 'hashPasswordForCookie')) {


### PR DESCRIPTION
The users password may be null at this point.

This PR fixes a type error introduced in #578 where a user may be logged in using passwordless authentication (such as magic links or OTP)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
