### PR TITLE
Add optional last_used_at tracking configuration

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -51,6 +51,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Track Last Used At
+    |--------------------------------------------------------------------------
+    |
+    | This value controls whether Sanctum will track the last time a token
+    | was used. When enabled, each token authentication will update the
+    | "last_used_at" timestamp. Disable this to reduce database writes
+    | in high-traffic applications with millions of users.
+    |
+    */
+
+    'track_last_used_at' => env('SANCTUM_TRACK_LAST_USED_AT', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Token Prefix
     |--------------------------------------------------------------------------
     |

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -51,20 +51,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Track Last Used At
-    |--------------------------------------------------------------------------
-    |
-    | This value controls whether Sanctum will track the last time a token
-    | was used. When enabled, each token authentication will update the
-    | "last_used_at" timestamp. Disable this to reduce database writes
-    | in high-traffic applications with millions of users.
-    |
-    */
-
-    'track_last_used_at' => env('SANCTUM_TRACK_LAST_USED_AT', true),
-
-    /*
-    |--------------------------------------------------------------------------
     | Token Prefix
     |--------------------------------------------------------------------------
     |

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -31,17 +31,26 @@ class Guard
     protected $provider;
 
     /**
+     * Whether to track the last used timestamp.
+     *
+     * @var bool
+     */
+    protected $trackLastUsedAt;
+
+    /**
      * Create a new guard instance.
      *
      * @param  \Illuminate\Contracts\Auth\Factory  $auth
      * @param  int  $expiration
      * @param  string  $provider
+     * @param  bool  $trackLastUsedAt
      */
-    public function __construct(AuthFactory $auth, $expiration = null, $provider = null)
+    public function __construct(AuthFactory $auth, $expiration = null, $provider = null, $trackLastUsedAt = true)
     {
         $this->auth = $auth;
         $this->expiration = $expiration;
         $this->provider = $provider;
+        $this->trackLastUsedAt = $trackLastUsedAt;
     }
 
     /**
@@ -76,7 +85,9 @@ class Guard
 
             event(new TokenAuthenticated($accessToken));
 
-            $this->updateLastUsedAt($accessToken);
+            if ($this->trackLastUsedAt) {
+                $this->updateLastUsedAt($accessToken);
+            }
 
             return $tokenable;
         }

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -107,7 +107,7 @@ class SanctumServiceProvider extends ServiceProvider
                 $auth,
                 config('sanctum.expiration'),
                 $config['provider'],
-                config('sanctum.track_last_used_at', true)
+                config('sanctum.last_used_at', true)
             ),
             request(),
             $auth->createUserProvider($config['provider'] ?? null)

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -103,7 +103,12 @@ class SanctumServiceProvider extends ServiceProvider
     protected function createGuard($auth, $config)
     {
         return new RequestGuard(
-            new Guard($auth, config('sanctum.expiration'), $config['provider']),
+            new Guard(
+                $auth,
+                config('sanctum.expiration'),
+                $config['provider'],
+                config('sanctum.track_last_used_at', true)
+            ),
             request(),
             $auth->createUserProvider($config['provider'] ?? null)
         );

--- a/tests/Feature/GuardTest.php
+++ b/tests/Feature/GuardTest.php
@@ -418,4 +418,65 @@ class GuardTest extends TestCase
             ['Bearer 1ABC|'],
         ];
     }
+
+    public function test_last_used_at_is_not_tracked_when_disabled()
+    {
+        $factory = Mockery::mock(AuthFactory::class);
+
+        $guard = new Guard($factory, null, 'users', false);
+
+        $webGuard = Mockery::mock(stdClass::class);
+
+        $factory->shouldReceive('guard')
+            ->with('web')
+            ->andReturn($webGuard);
+
+        $webGuard->shouldReceive('user')->once()->andReturn(null);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('Authorization', 'Bearer test');
+
+        $token = PersonalAccessTokenFactory::new()->for(
+            $user = UserFactory::new()->create(), 'tokenable'
+        )->create([
+            'name' => 'Test',
+            'last_used_at' => null,
+        ]);
+
+        $returnedUser = $guard->__invoke($request);
+
+        $this->assertEquals($user->id, $returnedUser->id);
+        $this->assertEquals($token->id, $returnedUser->currentAccessToken()->id);
+        $this->assertNull($returnedUser->currentAccessToken()->last_used_at);
+    }
+
+    public function test_last_used_at_is_tracked_when_enabled()
+    {
+        $factory = Mockery::mock(AuthFactory::class);
+
+        $guard = new Guard($factory, null, 'users', true);
+
+        $webGuard = Mockery::mock(stdClass::class);
+
+        $factory->shouldReceive('guard')
+            ->with('web')
+            ->andReturn($webGuard);
+
+        $webGuard->shouldReceive('user')->once()->andReturn(null);
+
+        $request = Request::create('/', 'GET');
+        $request->headers->set('Authorization', 'Bearer test');
+
+        $token = PersonalAccessTokenFactory::new()->for(
+            $user = UserFactory::new()->create(), 'tokenable'
+        )->create([
+            'name' => 'Test',
+        ]);
+
+        $returnedUser = $guard->__invoke($request);
+
+        $this->assertEquals($user->id, $returnedUser->id);
+        $this->assertEquals($token->id, $returnedUser->currentAccessToken()->id);
+        $this->assertInstanceOf(DateTimeInterface::class, $returnedUser->currentAccessToken()->last_used_at);
+    }
 }


### PR DESCRIPTION
Add track_last_used_at config to allow disabling timestamp updates on token authentication for reduced database writes in high-traffic apps.                                                                               