### PR TITLE
[4.x] Rename CSRF middleware to PreventRequestForgery

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -78,7 +78,7 @@ return [
     'middleware' => [
         'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
         'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
-        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+        'prevent_request_forgery' => Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class,
     ],
 
 ];

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -51,7 +51,7 @@ class EnsureFrontendRequestsAreStateful
             config('sanctum.middleware.encrypt_cookies', \Illuminate\Cookie\Middleware\EncryptCookies::class),
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
-            config('sanctum.middleware.validate_csrf_token', config('sanctum.middleware.verify_csrf_token', \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class)),
+            config('sanctum.middleware.prevent_request_forgery', \Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class),
             config('sanctum.middleware.authenticate_session'),
         ])));
 

--- a/tests/Controller/AuthenticateRequestsTest.php
+++ b/tests/Controller/AuthenticateRequestsTest.php
@@ -25,7 +25,7 @@ class AuthenticateRequestsTest extends TestCase
             'auth.providers.users.model' => User::class,
             'database.default' => 'testing',
             'sanctum.middleware.encrypt_cookies' => \Illuminate\Cookie\Middleware\EncryptCookies::class,
-            'sanctum.middleware.verify_csrf_token' => \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
+            'sanctum.middleware.prevent_request_forgery' => \Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class,
         ]);
     }
 

--- a/tests/Controller/FrontendRequestsAreStatefulTest.php
+++ b/tests/Controller/FrontendRequestsAreStatefulTest.php
@@ -25,7 +25,7 @@ class FrontendRequestsAreStatefulTest extends TestCase
             'auth.providers.users.model' => User::class,
             'database.default' => 'testing',
             'sanctum.middleware.encrypt_cookies' => \Illuminate\Cookie\Middleware\EncryptCookies::class,
-            'sanctum.middleware.verify_csrf_token' => \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
+            'sanctum.middleware.prevent_request_forgery' => \Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class,
         ]);
     }
 


### PR DESCRIPTION
## Summary

This PR updates the CSRF middleware usage to align with `Laravel 13`.

The middleware has been renamed from `VerifyCsrfToken` and `ValidateCsrfToken` to `PreventRequestForgery`, and the previous versions are now deprecated. 
The current configuration was still using the old middleware, which caused deprecation warnings in the IDE.

This change was made following issue #588, which highlighted this deprecation.

## Breaking Changes

The configuration key has been renamed from `validate_csrf_token` to `prevent_request_forgery` to stay consistent with the new middleware naming.  

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
