### PR TITLE
Change can and cant methods to accept arrays

### DIFF
--- a/src/Contracts/HasAbilities.php
+++ b/src/Contracts/HasAbilities.php
@@ -10,7 +10,7 @@ interface HasAbilities
      * @param  string  $ability
      * @return bool
      */
-    public function can($ability);
+    public function can(array $ability);
 
     /**
      * Determine if the token is missing a given ability.
@@ -18,5 +18,5 @@ interface HasAbilities
      * @param  string  $ability
      * @return bool
      */
-    public function cant($ability);
+    public function cant(array $ability);
 }


### PR DESCRIPTION
Updated method signatures for can() and cant() to accept an array of abilities
rather than a single string, enabling batch ability checks.