### PR TITLE
[4.x] Make route registration configurable

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -66,6 +66,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sanctum Route Registration
+    |--------------------------------------------------------------------------
+    |
+    | By setting this value to false, you are instructing Sanctum to ignore
+    | its default route registration. This is useful when you are using
+    | purely token-based authentication and do not need CSRF protection.
+    |
+    */
+    'routes' => env('SANCTUM_REGISTER_ROUTES', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Sanctum Middleware
     |--------------------------------------------------------------------------
     |

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -74,6 +74,7 @@ return [
     | purely token-based authentication and do not need CSRF protection.
     |
     */
+
     'routes' => env('SANCTUM_REGISTER_ROUTES', true),
 
     /*


### PR DESCRIPTION
This PR explicitly adds the routes option to the ``config/sanctum.php`` configuration file. Although Sanctum's service provider already checks for this configuration key internally to determine route registration, it is currently missing from the default configuration file published by the package.

https://github.com/laravel/sanctum/blob/70546ceb3f4089e2e2e02ae8fd3825f48d6dc5c2/src/SanctumServiceProvider.php#L68-L70

With this change, a new boolean environment variable, ``SANCTUM_REGISTER_ROUTES`` is introduced, allowing to dynamically enable or disable the registration of default Sanctum routes directly from the ``.env`` file.

# Motivation

In stateless API environments, the default session-based routes provided by Sanctum are often unnecessary.

# Testing

1. Add ``SANCTUM_REGISTER_ROUTES=false`` to your ``.env``

2. Run ``php artisan route:list``

3. Confirm that the ``/sanctum/csrf-cookie`` and other default Sanctum routes are no longer registered