### PR TITLE
[4.x] Make 'last_used_at' timestamp update configurable

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -66,6 +66,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Update Last Used At Timestamp
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether Sanctum updates the 'last_used_at' column
+    | in the database every time a personal access token is used. Disabling
+    | this feature can significantly reduce database write operations and
+    | improve overall API performance for high-concurrency environments.
+    |
+    */
+
+    'last_used_at' => env('SANCTUM_UPDATE_LAST_USED_AT', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Sanctum Middleware
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This PR explicitly adds the ``last_used_at`` option to the ``config/sanctum.php`` configuration file. While Sanctum already supports this key to toggle the updating of the token's last usage timestamp, it was not included in the default published configuration.

https://github.com/laravel/sanctum/blob/70546ceb3f4089e2e2e02ae8fd3825f48d6dc5c2/src/SanctumServiceProvider.php#L105-L117

PR #583 for additional references.

With this change, a new boolean environment variable, ``SANCTUM_UPDATE_LAST_USED_AT`` is introduced, allowing to dynamically enable or disable this feature directly from the ``.env`` file.

# Motivation

In high-concurrency environments, updating the ``last_used_at`` column on every request can generate a significant amount of database write overhead.

# Testing

1. Add ``SANCTUM_UPDATE_LAST_USED_AT=false`` to your ``.env``

2. Authenticate a request using a Personal Access Token.

4. Verify in the ``personal_access_tokens`` table that the ``last_used_at`` column for that token remains unchanged.

5. Set the variable to ``true`` and confirm the timestamp updates as expected upon use.