### PR TITLE
[4.x] Resolve CSRF middleware compatibility across Laravel versions

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
 use Laravel\Sanctum\Sanctum;
 
@@ -81,7 +80,7 @@ return [
     'middleware' => [
         'authenticate_session' => AuthenticateSession::class,
         'encrypt_cookies' => EncryptCookies::class,
-        'validate_csrf_token' => ValidateCsrfToken::class,
+        'validate_csrf_token' => Sanctum::csrfMiddleware(),
     ],
 
 ];

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -51,7 +51,10 @@ class EnsureFrontendRequestsAreStateful
             config('sanctum.middleware.encrypt_cookies', \Illuminate\Cookie\Middleware\EncryptCookies::class),
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
-            config('sanctum.middleware.validate_csrf_token', config('sanctum.middleware.verify_csrf_token', \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class)),
+            config('sanctum.middleware.validate_csrf_token')
+                ?? config('sanctum.middleware.prevent_request_forgery')
+                ?? config('sanctum.middleware.verify_csrf_token')
+                ?? Sanctum::csrfMiddleware(),
             config('sanctum.middleware.authenticate_session'),
         ])));
 

--- a/src/Sanctum.php
+++ b/src/Sanctum.php
@@ -38,6 +38,24 @@ class Sanctum
     public static $currentRequestHostPlaceholder = '__SANCTUM_CURRENT_REQUEST_HOST__';
 
     /**
+     * Get the default CSRF middleware class for the installed Laravel version.
+     *
+     * @return class-string
+     */
+    public static function csrfMiddleware(): string
+    {
+        if (class_exists(\Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class)) {
+            return \Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class;
+        }
+
+        if (class_exists(\Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class)) {
+            return \Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class;
+        }
+
+        return \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class;
+    }
+
+    /**
      * Get the current application URL from the "APP_URL" environment variable - with port.
      *
      * @return string

--- a/tests/Unit/CsrfMiddlewareTest.php
+++ b/tests/Unit/CsrfMiddlewareTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Sanctum\Tests\Unit;
+
+use Laravel\Sanctum\Sanctum;
+use Orchestra\Testbench\TestCase;
+
+class CsrfMiddlewareTest extends TestCase
+{
+    public function test_csrf_middleware_resolves_to_an_existing_class()
+    {
+        $middleware = Sanctum::csrfMiddleware();
+
+        $this->assertTrue(class_exists($middleware));
+    }
+}


### PR DESCRIPTION
## Summary

This PR resolves CSRF middleware deprecation warnings introduced in Laravel 13 while maintaining compatibility with Laravel 11 and 12.

Instead of directly replacing the middleware with `PreventRequestForgery` (which would break older Laravel versions), Sanctum now resolves the appropriate middleware dynamically at runtime.

## Changes

### `Sanctum::csrfMiddleware()`

Added a new helper method in `src/Sanctum.php` that resolves the correct middleware depending on the installed Laravel version:

* Laravel 13+ → `PreventRequestForgery`
* Laravel 11/12 → `ValidateCsrfToken`
* older versions → `VerifyCsrfToken`

### `config/sanctum.php`

Replaced the direct reference to the deprecated middleware:

```php
'validate_csrf_token' => Sanctum::csrfMiddleware(),
```

This removes IDE deprecation warnings from the published config while preserving backward compatibility.

### `EnsureFrontendRequestsAreStateful`

Updated the stateful middleware pipeline fallback resolution to support:

* `validate_csrf_token`
* `prevent_request_forgery`
* `verify_csrf_token`

falling back to `Sanctum::csrfMiddleware()` when none are defined.

This keeps compatibility with existing published configs while also allowing the newer naming convention without introducing breaking changes.

### Tests

Added `tests/Unit/CsrfMiddlewareTest.php` to ensure the resolved middleware class exists across supported Laravel versions.

## Compatibility

No breaking changes were introduced.

* The `validate_csrf_token` config key remains unchanged.
* Laravel 11, 12, and 13 remain supported.

## Validation

* 75 tests passing
* PHPStan passing without errors
