### PR TITLE
Change separator from `|` to `.` for tokens to be more compliant with advanced standards like OAuth

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -99,11 +99,11 @@ class Guard
      */
     protected function isValidBearerToken(?string $token = null)
     {
-        if (! is_null($token) && str_contains($token, '|')) {
+        if (! is_null($token) && str_contains($token, '.')) {
             $model = new Sanctum::$personalAccessTokenModel;
 
             if ($model->getKeyType() === 'int') {
-                [$id, $token] = explode('|', $token, 2);
+                [$id, $token] = explode('.', $token, 2);
 
                 return ctype_digit($id) && ! empty($token);
             }

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -68,7 +68,7 @@ trait HasApiTokens
             'expires_at' => $expiresAt,
         ]);
 
-        return new NewAccessToken($token, $token->getKey().'|'.$plainTextToken);
+        return new NewAccessToken($token, $token->getKey().'.'.$plainTextToken);
     }
 
     /**

--- a/src/PersonalAccessToken.php
+++ b/src/PersonalAccessToken.php
@@ -57,11 +57,11 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public static function findToken($token)
     {
-        if (strpos($token, '|') === false) {
+        if (strpos($token, '.') === false) {
             return static::where('token', hash('sha256', $token))->first();
         }
 
-        [$id, $token] = explode('|', $token, 2);
+        [$id, $token] = explode('.', $token, 2);
 
         if ($instance = static::find($id)) {
             return hash_equals($instance->token, hash('sha256', $token)) ? $instance : null;

--- a/tests/Feature/HasApiTokensTest.php
+++ b/tests/Feature/HasApiTokensTest.php
@@ -21,7 +21,7 @@ class HasApiTokensTest extends TestCase
 
         $newToken = $class->createToken('test', ['foo'], $time);
 
-        [$id, $token] = explode('|', $newToken->plainTextToken);
+        [$id, $token] = explode('.', $newToken->plainTextToken);
 
         $this->assertEquals(
             $newToken->accessToken->token,
@@ -70,7 +70,7 @@ class HasApiTokensTest extends TestCase
 
         $newToken = $class->createToken('test', ['foo']);
 
-        [$id, $token] = explode('|', $newToken->plainTextToken);
+        [$id, $token] = explode('.', $newToken->plainTextToken);
         $splitToken = explode('_', $token);
         $tokenEntropy = substr(end($splitToken), 0, -8);
 


### PR DESCRIPTION
I understand that Sanctum is not OAuth provider itself, but changing separators from pipes to dots would make tokens consumable by some other libraries in different languages (Kotlin, etc.), which now treat Sanctum’s tokens as invalid by default because of `|` separators.

See RFC 6750: https://datatracker.ietf.org/doc/html/rfc6750#section-2.1