### PR TITLE
Add doctor diagnostics

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,6 @@ permissions:
 
 jobs:
   tests:
-    uses: laravel/.github/.github/workflows/static-analysis.yml@9c15e86fffce728fb6c50ebeae24fd63e98f4d1d # main
+    uses: laravel/.github/.github/workflows/static-analysis.yml@41cb33d868e3f67ea2c9bb53f1ebd9a379400f63 # main
+    with:
+      php: "8.4"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,10 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Remove incompatible dependencies
+        if: matrix.laravel < 12 || matrix.php < 8.3
+        run: composer remove laravel/doctor --dev --no-update --no-interaction
+
       - name: Install dependencies
         run: |
            composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts=^${{ matrix.laravel }}"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "laravel/doctor": "^0.1",
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^9.15|^10.8|^11.0",
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^2.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/console": "^7.0|^8.0"
     },
     "require-dev": {
+        "laravel/doctor": "^0.1",
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^9.15|^10.8|^11.0",
         "phpstan/phpstan": "^1.10"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,9 @@
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
+        <testsuite name="Diagnostics">
+            <directory suffix="Test.php">./tests/Diagnostics</directory>
+        </testsuite>
     </testsuites>
     <php>
         <env name="APP_KEY" value="base64:uz4B1RtFO57QGzbZX1kRYX9hIRB50+QzqFeg9zbFJlY="/>

--- a/src/Diagnostics/FindsApiTokenModels.php
+++ b/src/Diagnostics/FindsApiTokenModels.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Sanctum\Diagnostics;
+
+use Laravel\Sanctum\HasApiTokens;
+
+trait FindsApiTokenModels
+{
+    /**
+     * Get the authentication provider models that issue Sanctum API tokens.
+     *
+     * @return list<class-string>
+     */
+    protected function apiTokenModels(): array
+    {
+        $providers = config('auth.providers');
+
+        if (! is_array($providers)) {
+            return [];
+        }
+
+        return collect($providers)
+            ->filter(fn ($provider): bool => is_array($provider) && ($provider['driver'] ?? null) === 'eloquent')
+            ->map(fn (array $provider) => $provider['model'] ?? null)
+            ->filter(fn ($model): bool => is_string($model) && class_exists($model))
+            ->filter(fn (string $model): bool => in_array(HasApiTokens::class, class_uses_recursive($model), true))
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/src/Diagnostics/ResolvesStatefulFrontend.php
+++ b/src/Diagnostics/ResolvesStatefulFrontend.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Laravel\Sanctum\Diagnostics;
+
+use Illuminate\Contracts\Http\Kernel;
+use Laravel\Doctor\Support\Configured;
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+
+trait ResolvesStatefulFrontend
+{
+    /**
+     * Determine whether the stateful API middleware is enabled.
+     */
+    protected function statefulApiIsEnabled(): bool
+    {
+        // Middleware registered in bootstrap/app.php lives on the HTTP kernel and is
+        // only synced to the router once the kernel is resolved, which never happens
+        // in an artisan process, so both sources must be consulted.
+        $groups = app('router')->getMiddlewareGroups();
+        $kernel = app(Kernel::class);
+
+        if (method_exists($kernel, 'getMiddlewareGroups')) {
+            $groups = array_merge_recursive($groups, $kernel->getMiddlewareGroups());
+        }
+
+        foreach ($groups as $middleware) {
+            if (in_array(EnsureFrontendRequestsAreStateful::class, $middleware, true)) {
+                return true;
+            }
+        }
+
+        return method_exists($kernel, 'getGlobalMiddleware')
+            && in_array(EnsureFrontendRequestsAreStateful::class, $kernel->getGlobalMiddleware(), true);
+    }
+
+    /**
+     * Get the host browsers send frontend requests from.
+     *
+     * Browsers send the frontend's origin as the referer, so a configured
+     * frontend URL supersedes the application URL, which may be an API
+     * host that never serves the frontend itself.
+     */
+    protected function frontendHost(bool $withPort = false): ?string
+    {
+        foreach (['app.frontend_url', 'app.url'] as $key) {
+            $host = $this->urlHost(Configured::string($key), $withPort);
+
+            if ($host !== null) {
+                return $host;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the host the application is served from.
+     */
+    protected function applicationHost(bool $withPort = false): ?string
+    {
+        return $this->urlHost(Configured::string('app.url'), $withPort);
+    }
+
+    /**
+     * Extract the host from a URL.
+     */
+    private function urlHost(?string $url, bool $withPort): ?string
+    {
+        $host = $url === null ? null : parse_url($url, PHP_URL_HOST);
+
+        if (! is_string($host) || $host === '') {
+            return null;
+        }
+
+        $port = $url === null ? null : parse_url($url, PHP_URL_PORT);
+
+        return $withPort && is_int($port) ? "{$host}:{$port}" : $host;
+    }
+}

--- a/src/Diagnostics/SanctumExpiredTokensArePruned.php
+++ b/src/Diagnostics/SanctumExpiredTokensArePruned.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Laravel\Sanctum\Diagnostics;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\EnvironmentMode;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Sanctum\Sanctum;
+use Throwable;
+
+class SanctumExpiredTokensArePruned extends Diagnostic
+{
+    use FindsApiTokenModels;
+
+    public string $name = 'Expired Sanctum tokens are pruned';
+
+    public string $group = 'sanctum';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'No authentication provider model uses Sanctum API tokens.',
+            'scheduled' => 'Expired Sanctum token pruning is scheduled.',
+            'no-expiration' => 'Sanctum tokens are not configured to expire, so pruning is not required.',
+            'cannot-inspect' => 'The database could not be inspected for expiring Sanctum tokens.',
+            'not-scheduled' => Message::make(
+                summary: 'Expired Sanctum tokens are not pruned.',
+                remediation: 'Schedule `sanctum:prune-expired` daily so the personal access tokens table does not grow unbounded.',
+            )->link(Link::docs('sanctum', 'token-expiration')),
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        if ($this->apiTokenModels() === []) {
+            return $this->skip('not-used');
+        }
+
+        if ($this->pruneIsScheduled()) {
+            return $this->pass('scheduled');
+        }
+
+        $expiring = $this->tokensExpire();
+
+        if ($expiring === null) {
+            return $this->skip('cannot-inspect');
+        }
+
+        if ($expiring === false) {
+            return $this->pass('no-expiration');
+        }
+
+        return EnvironmentMode::current()->isProduction()
+            ? $this->warn('not-scheduled')
+            : $this->notice('not-scheduled');
+    }
+
+    /**
+     * Determine whether token pruning is on the application's schedule.
+     */
+    private function pruneIsScheduled(): bool
+    {
+        foreach (app(Schedule::class)->events() as $event) {
+            if (str_contains((string) $event->command, 'sanctum:prune-expired')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether any issued tokens expire, or null when the database cannot be inspected.
+     *
+     * Tokens expire through the global expiration setting or through
+     * per-token expires_at values passed when the token was created.
+     */
+    private function tokensExpire(): ?bool
+    {
+        if (is_numeric(config('sanctum.expiration'))) {
+            return true;
+        }
+
+        try {
+            return Sanctum::personalAccessTokenModel()::query()->whereNotNull('expires_at')->exists();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Diagnostics/SanctumSchemaIsReady.php
+++ b/src/Diagnostics/SanctumSchemaIsReady.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Laravel\Sanctum\Diagnostics;
+
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Sanctum\Sanctum;
+use Throwable;
+
+class SanctumSchemaIsReady extends Diagnostic
+{
+    use FindsApiTokenModels;
+
+    public string $name = 'Sanctum database schema is ready';
+
+    public string $group = 'sanctum';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-used' => 'No authentication provider model uses Sanctum API tokens.',
+            'not-ready' => Message::make(
+                summary: 'The Sanctum personal access tokens table is missing.',
+                remediation: 'Run `php artisan vendor:publish --tag=sanctum-migrations` and `php artisan migrate` to create the table.',
+            )->link(Link::docs('sanctum', 'api-token-authentication')),
+            'cannot-inspect' => 'The database could not be inspected for the personal access tokens table.',
+            'ready' => 'The [{table}] table is available for Sanctum personal access tokens.',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        if ($this->apiTokenModels() === []) {
+            return $this->skip('not-used');
+        }
+
+        $model = new (Sanctum::personalAccessTokenModel());
+
+        try {
+            $connection = $model->getConnection();
+            $table = $model->getTable();
+
+            $exists = $connection->getSchemaBuilder()->hasTable($table);
+        } catch (Throwable $e) {
+            return $this->skip('cannot-inspect')->withDetails($e->getMessage());
+        }
+
+        if (! $exists) {
+            return $this->fail('not-ready')
+                ->withDetails("The [{$connection->getName()}.{$table}] table does not exist.");
+        }
+
+        return $this->pass('ready', ['table' => $table]);
+    }
+}

--- a/src/Diagnostics/SanctumSessionDomainCoversFrontend.php
+++ b/src/Diagnostics/SanctumSessionDomainCoversFrontend.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Laravel\Sanctum\Diagnostics;
+
+use Illuminate\Support\Str;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Configured;
+
+class SanctumSessionDomainCoversFrontend extends Diagnostic
+{
+    use ResolvesStatefulFrontend;
+
+    public string $name = 'Sanctum session cookies reach the frontend';
+
+    public string $group = 'sanctum';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-stateful' => 'The stateful API middleware is not enabled, so the session cookie domain was not checked.',
+            'no-app-url' => 'The application URL is not configured, so the session cookie domain was not checked.',
+            'same-host' => 'The frontend and API share the [{host}] host, so no session cookie domain is required.',
+            'no-shared-domain' => Message::make(
+                summary: 'The frontend [{frontend}] and API [{app}] do not share a parent domain, so session cookies cannot be shared.',
+                remediation: 'Serve the frontend and API from a common parent domain, or authenticate with API tokens instead.',
+            )->link(Link::docs('sanctum', 'spa-authentication')),
+            'not-set' => Message::make(
+                summary: 'The session cookie domain is not set, but the frontend [{frontend}] and API [{app}] are on different hosts.',
+                remediation: 'Set SESSION_DOMAIN to [{suggested}] so authentication cookies are shared between the frontend and the API.',
+            )->link(Link::docs('sanctum', 'spa-authentication')),
+            'not-covered' => Message::make(
+                summary: 'The session cookie domain [{domain}] does not cover both the frontend [{frontend}] and the API [{app}].',
+                remediation: 'Set SESSION_DOMAIN to [{suggested}] so authentication cookies are shared between the frontend and the API.',
+            )->link(Link::docs('sanctum', 'spa-authentication')),
+            'covered' => 'The session cookie domain [{domain}] covers the frontend and the API.',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        if (! $this->statefulApiIsEnabled()) {
+            return $this->skip('not-stateful');
+        }
+
+        $frontend = $this->frontendHost();
+        $app = $this->applicationHost();
+
+        if ($frontend === null || $app === null) {
+            return $this->skip('no-app-url');
+        }
+
+        if (strcasecmp($frontend, $app) === 0) {
+            return $this->pass('same-host', ['host' => $app]);
+        }
+
+        $suggested = $this->sharedParentDomain($frontend, $app);
+
+        if ($suggested === null) {
+            return $this->fail('no-shared-domain', ['frontend' => $frontend, 'app' => $app]);
+        }
+
+        $domain = Configured::string('session.domain');
+
+        if ($domain === null) {
+            return $this->fail('not-set', [
+                'frontend' => $frontend,
+                'app' => $app,
+                'suggested' => $suggested,
+            ]);
+        }
+
+        if (! $this->covers($domain, $frontend) || ! $this->covers($domain, $app)) {
+            return $this->fail('not-covered', [
+                'domain' => $domain,
+                'frontend' => $frontend,
+                'app' => $app,
+                'suggested' => $suggested,
+            ]);
+        }
+
+        return $this->pass('covered', ['domain' => $domain]);
+    }
+
+    /**
+     * Determine whether a cookie domain covers a host.
+     */
+    private function covers(string $domain, string $host): bool
+    {
+        $domain = strtolower(ltrim($domain, '.'));
+        $host = strtolower($host);
+
+        return $host === $domain || Str::endsWith($host, '.'.$domain);
+    }
+
+    /**
+     * Get the parent domain shared by two hosts, if any.
+     */
+    private function sharedParentDomain(string $first, string $second): ?string
+    {
+        if (filter_var($first, FILTER_VALIDATE_IP) || filter_var($second, FILTER_VALIDATE_IP)) {
+            return null;
+        }
+
+        $first = array_reverse(explode('.', strtolower($first)));
+        $second = array_reverse(explode('.', strtolower($second)));
+
+        $shared = [];
+
+        foreach ($first as $index => $label) {
+            if (($second[$index] ?? null) !== $label) {
+                break;
+            }
+
+            $shared[] = $label;
+        }
+
+        return count($shared) >= 2 ? '.'.implode('.', array_reverse($shared)) : null;
+    }
+}

--- a/src/Diagnostics/SanctumStatefulDomainsCoverAppUrl.php
+++ b/src/Diagnostics/SanctumStatefulDomainsCoverAppUrl.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Laravel\Sanctum\Diagnostics;
+
+use Illuminate\Support\Str;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Details;
+use Laravel\Sanctum\Sanctum;
+
+class SanctumStatefulDomainsCoverAppUrl extends Diagnostic
+{
+    use ResolvesStatefulFrontend;
+
+    public string $name = 'Sanctum stateful domains cover the frontend';
+
+    public string $group = 'sanctum';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'not-stateful' => 'The stateful API middleware is not enabled, so stateful domains were not checked.',
+            'no-app-url' => 'The application URL is not configured, so stateful domains were not checked.',
+            'no-domains' => Message::make(
+                summary: 'No Sanctum stateful domains are configured.',
+                remediation: 'Set SANCTUM_STATEFUL_DOMAINS to the hosts the frontend is served from so its requests receive session cookies.',
+            )->link(Link::docs('sanctum', 'spa-authentication')),
+            'not-covered' => Message::make(
+                summary: 'The Sanctum stateful domains do not include the frontend host [{host}].',
+                remediation: 'Add [{host}] to SANCTUM_STATEFUL_DOMAINS so frontend requests receive session cookies.',
+            )->link(Link::docs('sanctum', 'spa-authentication')),
+            'covered' => 'The Sanctum stateful domains include the frontend host [{host}].',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        if (! $this->statefulApiIsEnabled()) {
+            return $this->skip('not-stateful');
+        }
+
+        $host = $this->frontendHost(withPort: true);
+
+        if ($host === null) {
+            return $this->skip('no-app-url');
+        }
+
+        $stateful = config('sanctum.stateful');
+        $domains = is_array($stateful) ? array_filter($stateful) : [];
+
+        if ($domains === []) {
+            return $this->fail('no-domains');
+        }
+
+        if (! Str::is($this->statefulPatterns($domains), $host.'/')) {
+            return $this->fail('not-covered', ['host' => $host])
+                ->withDetails(Details::bullets($this->configuredDomains($domains)));
+        }
+
+        return $this->pass('covered', ['host' => $host]);
+    }
+
+    /**
+     * Build the wildcard patterns the stateful middleware matches frontend requests against.
+     *
+     * Mirrors EnsureFrontendRequestsAreStateful::fromFrontend(), with the
+     * current-request-host placeholder resolved to the application host —
+     * the host requests hit when the frontend and API share an origin.
+     *
+     * @param  array<array-key, mixed>  $domains
+     * @return list<string>
+     */
+    private function statefulPatterns(array $domains): array
+    {
+        return collect($domains)
+            ->map(fn ($domain) => $domain === Sanctum::$currentRequestHostPlaceholder
+                ? $this->applicationHost(withPort: true)
+                : $domain)
+            ->filter(fn ($domain): bool => is_string($domain) && trim($domain) !== '')
+            ->map(fn (string $domain): string => trim($domain).'/*')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Get the configured stateful domains as displayable strings.
+     *
+     * @param  array<array-key, mixed>  $domains
+     * @return list<string>
+     */
+    private function configuredDomains(array $domains): array
+    {
+        return collect($domains)
+            ->filter(fn ($domain): bool => is_string($domain) && trim($domain) !== '')
+            ->map(fn (string $domain): string => trim($domain))
+            ->values()
+            ->all();
+    }
+}

--- a/src/SanctumServiceProvider.php
+++ b/src/SanctumServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Doctor\Doctor;
 use Laravel\Sanctum\Console\Commands\PruneExpired;
 use Laravel\Sanctum\Http\Controllers\CsrfCookieController;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
@@ -39,6 +40,8 @@ class SanctumServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->registerDiagnostics();
+
         if (app()->runningInConsole()) {
             $this->publishesMigrations([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
@@ -56,6 +59,23 @@ class SanctumServiceProvider extends ServiceProvider
         $this->defineRoutes();
         $this->configureGuard();
         $this->configureMiddleware();
+    }
+
+    /**
+     * Register the package's Doctor diagnostics.
+     *
+     * @return void
+     */
+    protected function registerDiagnostics()
+    {
+        if ($this->app->bound(Doctor::class)) {
+            $this->app->make(Doctor::class)->diagnostics([
+                Diagnostics\SanctumSchemaIsReady::class,
+                Diagnostics\SanctumExpiredTokensArePruned::class,
+                Diagnostics\SanctumStatefulDomainsCoverAppUrl::class,
+                Diagnostics\SanctumSessionDomainCoversFrontend::class,
+            ]);
+        }
     }
 
     /**

--- a/tests/Diagnostics/DiagnosticTestCase.php
+++ b/tests/Diagnostics/DiagnosticTestCase.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Laravel\Sanctum\Tests\Diagnostics;
+
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Foundation\Application;
+use Laravel\Doctor\DoctorServiceProvider;
+use Laravel\Sanctum\PersonalAccessToken;
+use Laravel\Sanctum\Sanctum;
+use Laravel\Sanctum\SanctumServiceProvider;
+use Orchestra\Testbench\TestCase;
+use Workbench\App\Models\User;
+
+abstract class DiagnosticTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (! class_exists(DoctorServiceProvider::class)) {
+            $this->markTestSkipped('laravel/doctor is not installed.');
+        }
+
+        parent::setUp();
+    }
+
+    /**
+     * Get the package providers.
+     *
+     * @param  Application  $app
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            SanctumServiceProvider::class,
+            DoctorServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Define the test environment.
+     *
+     * @param  Application  $app
+     */
+    protected function defineEnvironment($app)
+    {
+        $config = $app->make(Repository::class);
+
+        $config->set([
+            'app.url' => 'http://localhost',
+            'app.frontend_url' => null,
+            'auth.providers.users' => [
+                'driver' => 'eloquent',
+                'model' => User::class,
+            ],
+            'database.default' => 'testing',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
+
+        parent::tearDown();
+    }
+}

--- a/tests/Diagnostics/Fixtures/CustomPersonalAccessToken.php
+++ b/tests/Diagnostics/Fixtures/CustomPersonalAccessToken.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Sanctum\Tests\Diagnostics\Fixtures;
+
+use Laravel\Sanctum\PersonalAccessToken;
+
+class CustomPersonalAccessToken extends PersonalAccessToken
+{
+    protected $table = 'custom_personal_access_tokens';
+}

--- a/tests/Diagnostics/SanctumExpiredTokensArePrunedTest.php
+++ b/tests/Diagnostics/SanctumExpiredTokensArePrunedTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Laravel\Sanctum\Tests\Diagnostics;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Sanctum\Diagnostics\SanctumExpiredTokensArePruned;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class SanctumExpiredTokensArePrunedTest extends DiagnosticTestCase
+{
+    public function test_diagnostic_is_registered_with_doctor()
+    {
+        $this->assertContains(SanctumExpiredTokensArePruned::class, Doctor::registered());
+    }
+
+    public function test_diagnostic_skips_when_no_model_uses_api_tokens()
+    {
+        config(['auth.providers.users.model' => \Illuminate\Foundation\Auth\User::class]);
+
+        $result = (new SanctumExpiredTokensArePruned)->check();
+
+        $this->assertSame(Status::Skip, $result->status);
+        $this->assertSame('No authentication provider model uses Sanctum API tokens.', $result->summary);
+    }
+
+    public function test_diagnostic_passes_when_pruning_is_scheduled()
+    {
+        config(['sanctum.expiration' => 60]);
+
+        $schedule = new Schedule;
+        $schedule->command('sanctum:prune-expired')->daily();
+
+        $this->app->instance(Schedule::class, $schedule);
+
+        $result = (new SanctumExpiredTokensArePruned)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertSame('Expired Sanctum token pruning is scheduled.', $result->summary);
+    }
+
+    public function test_diagnostic_passes_when_tokens_never_expire()
+    {
+        $this->createTokensTable();
+
+        $result = (new SanctumExpiredTokensArePruned)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertSame('Sanctum tokens are not configured to expire, so pruning is not required.', $result->summary);
+    }
+
+    public function test_diagnostic_warns_when_pruning_is_not_scheduled_in_production()
+    {
+        config(['sanctum.expiration' => 60]);
+
+        $result = (new SanctumExpiredTokensArePruned)->check();
+
+        $this->assertSame(Status::Warn, $result->status);
+        $this->assertSame('Expired Sanctum tokens are not pruned.', $result->summary);
+        $this->assertStringContainsString('sanctum:prune-expired', $result->remediation);
+    }
+
+    public function test_diagnostic_notices_when_pruning_is_not_scheduled_outside_production()
+    {
+        config([
+            'sanctum.expiration' => 60,
+            'doctor.environments' => ['local' => ['testing']],
+        ]);
+
+        $result = (new SanctumExpiredTokensArePruned)->check();
+
+        $this->assertSame(Status::Notice, $result->status);
+        $this->assertSame('Expired Sanctum tokens are not pruned.', $result->summary);
+    }
+
+    public function test_diagnostic_detects_expiring_tokens_from_the_database()
+    {
+        $this->createTokensTable();
+
+        PersonalAccessToken::forceCreate([
+            'tokenable_type' => 'user',
+            'tokenable_id' => 1,
+            'name' => 'test',
+            'token' => hash('sha256', 'token'),
+            'abilities' => ['*'],
+            'expires_at' => now()->addDay(),
+        ]);
+
+        $result = (new SanctumExpiredTokensArePruned)->check();
+
+        $this->assertSame(Status::Warn, $result->status);
+        $this->assertSame('Expired Sanctum tokens are not pruned.', $result->summary);
+    }
+
+    public function test_diagnostic_skips_when_the_database_cannot_be_inspected()
+    {
+        $result = (new SanctumExpiredTokensArePruned)->check();
+
+        $this->assertSame(Status::Skip, $result->status);
+        $this->assertSame('The database could not be inspected for expiring Sanctum tokens.', $result->summary);
+    }
+
+    /**
+     * Create the personal access tokens table.
+     */
+    private function createTokensTable(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $blueprint): void {
+            $blueprint->id();
+            $blueprint->string('tokenable_type');
+            $blueprint->unsignedBigInteger('tokenable_id');
+            $blueprint->string('name');
+            $blueprint->string('token');
+            $blueprint->text('abilities')->nullable();
+            $blueprint->timestamp('expires_at')->nullable();
+            $blueprint->timestamps();
+        });
+    }
+}

--- a/tests/Diagnostics/SanctumSchemaIsReadyTest.php
+++ b/tests/Diagnostics/SanctumSchemaIsReadyTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Sanctum\Tests\Diagnostics;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Sanctum\Diagnostics\SanctumSchemaIsReady;
+use Laravel\Sanctum\Sanctum;
+use Laravel\Sanctum\Tests\Diagnostics\Fixtures\CustomPersonalAccessToken;
+
+class SanctumSchemaIsReadyTest extends DiagnosticTestCase
+{
+    public function test_diagnostic_is_registered_with_doctor()
+    {
+        $this->assertContains(SanctumSchemaIsReady::class, Doctor::registered());
+    }
+
+    public function test_diagnostic_skips_when_no_model_uses_api_tokens()
+    {
+        config(['auth.providers.users.model' => \Illuminate\Foundation\Auth\User::class]);
+
+        $result = (new SanctumSchemaIsReady)->check();
+
+        $this->assertSame(Status::Skip, $result->status);
+        $this->assertSame('No authentication provider model uses Sanctum API tokens.', $result->summary);
+    }
+
+    public function test_diagnostic_passes_when_the_tokens_table_exists()
+    {
+        $this->createTokensTable('personal_access_tokens');
+
+        $result = (new SanctumSchemaIsReady)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertSame('The [personal_access_tokens] table is available for Sanctum personal access tokens.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_tokens_table_is_missing()
+    {
+        $result = (new SanctumSchemaIsReady)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('The Sanctum personal access tokens table is missing.', $result->summary);
+        $this->assertStringContainsString('personal_access_tokens', $result->details);
+        $this->assertStringContainsString('sanctum-migrations', $result->remediation);
+        $this->assertStringContainsString('php artisan migrate', $result->remediation);
+    }
+
+    public function test_diagnostic_honors_a_custom_token_model()
+    {
+        Sanctum::usePersonalAccessTokenModel(CustomPersonalAccessToken::class);
+
+        $this->createTokensTable('custom_personal_access_tokens');
+
+        $result = (new SanctumSchemaIsReady)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertStringContainsString('custom_personal_access_tokens', $result->summary);
+    }
+
+    public function test_diagnostic_skips_when_the_database_cannot_be_inspected()
+    {
+        config(['database.default' => 'missing']);
+
+        $result = (new SanctumSchemaIsReady)->check();
+
+        $this->assertSame(Status::Skip, $result->status);
+        $this->assertSame('The database could not be inspected for the personal access tokens table.', $result->summary);
+        $this->assertStringContainsString('missing', $result->details);
+    }
+
+    /**
+     * Create a personal access tokens table.
+     */
+    private function createTokensTable(string $table): void
+    {
+        Schema::create($table, function (Blueprint $blueprint): void {
+            $blueprint->id();
+            $blueprint->timestamp('expires_at')->nullable();
+        });
+    }
+}

--- a/tests/Diagnostics/SanctumSessionDomainCoversFrontendTest.php
+++ b/tests/Diagnostics/SanctumSessionDomainCoversFrontendTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Laravel\Sanctum\Tests\Diagnostics;
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Sanctum\Diagnostics\SanctumSessionDomainCoversFrontend;
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+
+class SanctumSessionDomainCoversFrontendTest extends DiagnosticTestCase
+{
+    public function test_diagnostic_is_registered_with_doctor()
+    {
+        $this->assertContains(SanctumSessionDomainCoversFrontend::class, Doctor::registered());
+    }
+
+    public function test_diagnostic_skips_when_the_stateful_middleware_is_not_enabled()
+    {
+        $result = (new SanctumSessionDomainCoversFrontend)->check();
+
+        $this->assertSame(Status::Skip, $result->status);
+        $this->assertSame('The stateful API middleware is not enabled, so the session cookie domain was not checked.', $result->summary);
+    }
+
+    public function test_diagnostic_passes_when_the_frontend_and_api_share_a_host()
+    {
+        $this->enableStatefulApi();
+
+        $result = (new SanctumSessionDomainCoversFrontend)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertSame('The frontend and API share the [localhost] host, so no session cookie domain is required.', $result->summary);
+    }
+
+    public function test_diagnostic_ignores_ports_when_comparing_hosts()
+    {
+        $this->enableStatefulApi();
+
+        config([
+            'app.url' => 'http://localhost',
+            'app.frontend_url' => 'http://localhost:5173',
+        ]);
+
+        $result = (new SanctumSessionDomainCoversFrontend)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertSame('The frontend and API share the [localhost] host, so no session cookie domain is required.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_session_domain_is_not_set_for_cross_subdomain_hosts()
+    {
+        $this->enableStatefulApi();
+
+        config([
+            'app.url' => 'https://api.example.com',
+            'app.frontend_url' => 'https://app.example.com',
+        ]);
+
+        $result = (new SanctumSessionDomainCoversFrontend)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('The session cookie domain is not set, but the frontend [app.example.com] and API [api.example.com] are on different hosts.', $result->summary);
+        $this->assertStringContainsString('[.example.com]', $result->remediation);
+    }
+
+    public function test_diagnostic_passes_when_the_session_domain_covers_both_hosts()
+    {
+        $this->enableStatefulApi();
+
+        config([
+            'app.url' => 'https://api.example.com',
+            'app.frontend_url' => 'https://app.example.com',
+            'session.domain' => '.example.com',
+        ]);
+
+        $result = (new SanctumSessionDomainCoversFrontend)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertSame('The session cookie domain [.example.com] covers the frontend and the API.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_session_domain_covers_only_one_host()
+    {
+        $this->enableStatefulApi();
+
+        config([
+            'app.url' => 'https://api.example.com',
+            'app.frontend_url' => 'https://app.example.com',
+            'session.domain' => 'api.example.com',
+        ]);
+
+        $result = (new SanctumSessionDomainCoversFrontend)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('The session cookie domain [api.example.com] does not cover both the frontend [app.example.com] and the API [api.example.com].', $result->summary);
+        $this->assertStringContainsString('[.example.com]', $result->remediation);
+    }
+
+    public function test_diagnostic_fails_when_the_hosts_share_no_parent_domain()
+    {
+        $this->enableStatefulApi();
+
+        config([
+            'app.url' => 'https://api.example.com',
+            'app.frontend_url' => 'https://app.another.dev',
+        ]);
+
+        $result = (new SanctumSessionDomainCoversFrontend)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('The frontend [app.another.dev] and API [api.example.com] do not share a parent domain, so session cookies cannot be shared.', $result->summary);
+        $this->assertStringContainsString('API tokens', $result->remediation);
+    }
+
+    /**
+     * Register the stateful API middleware like Laravel's statefulApi() does.
+     */
+    private function enableStatefulApi(): void
+    {
+        $this->app['router']->middlewareGroup('api', [EnsureFrontendRequestsAreStateful::class]);
+    }
+}

--- a/tests/Diagnostics/SanctumStatefulDomainsCoverAppUrlTest.php
+++ b/tests/Diagnostics/SanctumStatefulDomainsCoverAppUrlTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Laravel\Sanctum\Tests\Diagnostics;
+
+use Illuminate\Contracts\Http\Kernel;
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Doctor\Results\Status;
+use Laravel\Sanctum\Diagnostics\SanctumStatefulDomainsCoverAppUrl;
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Laravel\Sanctum\Sanctum;
+
+class SanctumStatefulDomainsCoverAppUrlTest extends DiagnosticTestCase
+{
+    public function test_diagnostic_is_registered_with_doctor()
+    {
+        $this->assertContains(SanctumStatefulDomainsCoverAppUrl::class, Doctor::registered());
+    }
+
+    public function test_diagnostic_skips_when_the_stateful_middleware_is_not_enabled()
+    {
+        $result = (new SanctumStatefulDomainsCoverAppUrl)->check();
+
+        $this->assertSame(Status::Skip, $result->status);
+        $this->assertSame('The stateful API middleware is not enabled, so stateful domains were not checked.', $result->summary);
+    }
+
+    public function test_diagnostic_passes_when_the_default_domains_cover_the_app_url()
+    {
+        $this->enableStatefulApi();
+
+        $result = (new SanctumStatefulDomainsCoverAppUrl)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertSame('The Sanctum stateful domains include the frontend host [localhost].', $result->summary);
+    }
+
+    public function test_diagnostic_sees_stateful_middleware_registered_through_the_application_bootstrap()
+    {
+        // Middleware from bootstrap/app.php lives on the kernel and is not synced
+        // to the router in an artisan process.
+        app(Kernel::class)->setMiddlewareGroups(['api' => [EnsureFrontendRequestsAreStateful::class]]);
+        $this->app['router']->middlewareGroup('api', []);
+
+        $result = (new SanctumStatefulDomainsCoverAppUrl)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+    }
+
+    public function test_diagnostic_fails_when_the_app_url_is_not_covered()
+    {
+        $this->enableStatefulApi();
+
+        config([
+            'app.url' => 'https://example.com',
+            'sanctum.stateful' => ['localhost', '127.0.0.1'],
+        ]);
+
+        $result = (new SanctumStatefulDomainsCoverAppUrl)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('The Sanctum stateful domains do not include the frontend host [example.com].', $result->summary);
+        $this->assertStringContainsString('localhost', $result->details);
+        $this->assertStringContainsString('SANCTUM_STATEFUL_DOMAINS', $result->remediation);
+    }
+
+    public function test_diagnostic_prefers_the_frontend_url_over_the_app_url()
+    {
+        $this->enableStatefulApi();
+
+        config([
+            'app.url' => 'https://api.example.com',
+            'app.frontend_url' => 'https://app.example.com',
+            'sanctum.stateful' => ['app.example.com'],
+        ]);
+
+        $result = (new SanctumStatefulDomainsCoverAppUrl)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+        $this->assertSame('The Sanctum stateful domains include the frontend host [app.example.com].', $result->summary);
+    }
+
+    public function test_diagnostic_matches_ports_the_way_the_middleware_does()
+    {
+        $this->enableStatefulApi();
+
+        config([
+            'app.frontend_url' => 'http://localhost:5173',
+            'sanctum.stateful' => ['localhost'],
+        ]);
+
+        $result = (new SanctumStatefulDomainsCoverAppUrl)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('The Sanctum stateful domains do not include the frontend host [localhost:5173].', $result->summary);
+    }
+
+    public function test_diagnostic_supports_wildcard_domains()
+    {
+        $this->enableStatefulApi();
+
+        config([
+            'app.url' => 'https://tenant.example.com',
+            'sanctum.stateful' => ['*.example.com'],
+        ]);
+
+        $result = (new SanctumStatefulDomainsCoverAppUrl)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+    }
+
+    public function test_diagnostic_resolves_the_current_request_host_placeholder_to_the_app_host()
+    {
+        $this->enableStatefulApi();
+
+        config([
+            'app.url' => 'https://example.com',
+            'sanctum.stateful' => [Sanctum::$currentRequestHostPlaceholder],
+        ]);
+
+        $result = (new SanctumStatefulDomainsCoverAppUrl)->check();
+
+        $this->assertSame(Status::Pass, $result->status);
+    }
+
+    public function test_diagnostic_fails_when_no_domains_are_configured()
+    {
+        $this->enableStatefulApi();
+
+        config(['sanctum.stateful' => []]);
+
+        $result = (new SanctumStatefulDomainsCoverAppUrl)->check();
+
+        $this->assertSame(Status::Fail, $result->status);
+        $this->assertSame('No Sanctum stateful domains are configured.', $result->summary);
+    }
+
+    /**
+     * Register the stateful API middleware like Laravel's statefulApi() does.
+     */
+    private function enableStatefulApi(): void
+    {
+        $this->app['router']->middlewareGroup('api', [EnsureFrontendRequestsAreStateful::class]);
+    }
+}


### PR DESCRIPTION
This PR registers four Sanctum diagnostics with laravel/doctor when it is installed.

- **SanctumSchemaIsReady** fails if a model uses Sanctum API tokens but the personal access tokens table is missing.
- **SanctumExpiredTokensArePruned** checks that `sanctum:prune-expired` is scheduled when tokens can expire, either through `sanctum.expiration` or per-token `expires_at` values.
- **SanctumStatefulDomainsCoverAppUrl** fails if the stateful API middleware is enabled but the configured stateful domains don't match the frontend host, using the same wildcard matching as `EnsureFrontendRequestsAreStateful`.
- **SanctumSessionDomainCoversFrontend** verifies the session cookie domain covers both the frontend and API hosts when they differ, suggesting a shared parent domain, and fails when no common parent domain exists.