### PR TITLE
[4.x] Cast stateful domains environment value to string

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -18,7 +18,7 @@ return [
     |
     */
 
-    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+    'stateful' => explode(',', (string) env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         Sanctum::currentApplicationUrlWithPort(),


### PR DESCRIPTION
PHPStan reports an `argument.type` error when the published Sanctum configuration is analyzed in a Laravel application with Larastan:

```text
Parameter #2 $string of function explode expects string, bool|string given.
```

Laravel’s `env()` helper may return a boolean or string, while `explode()` expects a string. Casting the environment value at the configuration boundary preserves existing string behavior and keeps the published configuration compatible with static analysis in consuming applications.

Tests:
- `vendor/bin/phpunit --display-deprecations --fail-on-deprecation` (75 tests, 178 assertions)
- `php -l config/sanctum.php`